### PR TITLE
Fix tmux single-column render and wrong-agent-on-switch

### DIFF
--- a/PPG CLI/PPG CLI/ContentTabViewController.swift
+++ b/PPG CLI/PPG CLI/ContentTabViewController.swift
@@ -154,7 +154,6 @@ class ContentViewController: NSViewController {
         switch tab {
         case .manifestAgent(let agent, _):
             let pane = TerminalPane(agent: agent, sessionName: sessionName)
-            pane.startTmux()
             termView = pane
 
         case .agentGroup(let agents, let tmuxTarget, _):
@@ -169,7 +168,6 @@ class ContentViewController: NSViewController {
                 startedAt: lead.startedAt
             )
             let pane = TerminalPane(agent: groupAgent, sessionName: sessionName)
-            pane.startTmux()
             termView = pane
 
         case .sessionEntry(let entry, _):
@@ -185,7 +183,6 @@ class ContentViewController: NSViewController {
                     sessionId: entry.sessionId
                 )
                 let pane = TerminalPane(agent: agentModel, sessionName: sessionName)
-                pane.startTmux()
                 termView = pane
             } else {
                 let localTerm = ScrollableTerminalView(frame: containerView.bounds)


### PR DESCRIPTION
## Summary
- **Single-column render bug:** `startTmux()` was called before Auto Layout ran, so SwiftTerm opened a 1-column PTY. Tmux rewrapped all scrollback to 1 column permanently. Fixed by deferring process start to first `layout()` pass with a real frame.
- **Wrong agent on switch:** All TerminalPanes used `attach-session` to the same tmux session, sharing the "current window" — clicking one agent hijacked every other agent's view. Fixed by using tmux **grouped sessions** (`new-session -t`) which give each client independent window tracking, with `destroy-unattached on` for cleanup.

## Changes
- `TerminalPane.swift` — deferred start via `processStarted` flag in `layout()`, rewrote `startTmux()` to use grouped sessions
- `ContentTabViewController.swift` — removed explicit `pane.startTmux()` calls (TerminalPane now self-starts)

## Test plan
- [ ] Open PPG CLI app with multiple agents in different worktrees
- [ ] Verify first render shows correctly-wrapped content (no single-column text)
- [ ] Click between agents in sidebar — each should show its own terminal content
- [ ] Verify `tmux ls` shows grouped sessions (`ppg-view-<agentId>`) while viewing
- [ ] Close/terminate a TerminalPane — verify its grouped session is cleaned up
- [ ] Test agent groups (split panes in same window) still display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed terminal pane initialization to defer tmux session startup until after the layout frame is ready, preventing display issues and improving stability.
* Updated terminal pane management to use dedicated per-view tmux sessions instead of relying on default session attachment behavior, improving session isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->