### PR TITLE
Fix tmux send-keys not submitting Enter to Claude Code agents

### DIFF
--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -61,8 +61,12 @@ export async function splitPane(
 }
 
 export async function sendKeys(target: string, command: string): Promise<void> {
-  // Send command text with trailing newline in a single call
-  await execa('tmux', ['send-keys', '-t', target, '-l', command + '\n'], execaEnv);
+  // Send text as literal characters, then Enter as a named key.
+  // Using -l sends \n as LF (0x0a) which Ink-based CLIs like Claude Code
+  // treat as text insertion. Sending 'Enter' without -l sends CR (0x0d),
+  // which correctly triggers onSubmit in terminal apps.
+  await execa('tmux', ['send-keys', '-t', target, '-l', command], execaEnv);
+  await execa('tmux', ['send-keys', '-t', target, 'Enter'], execaEnv);
 }
 
 export async function sendLiteral(target: string, text: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixed ~50% failure rate where `tmux send-keys` text would appear in Claude Code input but Enter was never processed
- Root cause: `send-keys -l` with `\n` sends LF (0x0a) as a literal byte, but Ink-based CLIs treat LF as text insertion, not submission
- Fix: split into two calls — literal text send + named `Enter` key which delivers CR (0x0d) and correctly triggers onSubmit

## Test plan
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [x] All 37 existing tests pass
- [ ] Manual: run `ppg send <worktree> 'hello world'` multiple times — message should be both pasted AND submitted every time
- [ ] Manual: test with multi-line messages
- [ ] Manual: test with long messages (500+ chars)