### PR TITLE
Fix spawn/restart opening unwanted Terminal.app windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ program
   .option('-w, --worktree <id>', 'Add agent to existing worktree')
   .option('-c, --count <n>', 'Number of agents to spawn', (v: string) => Number(v), 1)
   .option('--split', 'Put all agents in one window as split panes')
-  .option('--no-open', 'Do not open a Terminal window for the spawned agents')
+  .option('--open', 'Open a Terminal window for the spawned agents')
   .option('--json', 'Output as JSON')
   .action(async (options) => {
     const { spawnCommand } = await import('./commands/spawn.js');
@@ -123,7 +123,7 @@ program
   .option('--var <key=value...>', 'Template variables', collectVars, [])
   .option('-n, --name <name>', 'Override worktree name')
   .option('-b, --base <branch>', 'Base branch for new worktree(s)')
-  .option('--no-open', 'Do not open Terminal windows')
+  .option('--open', 'Open Terminal windows for spawned agents')
   .option('--json', 'Output as JSON')
   .action(async (template, options) => {
     const { swarmCommand } = await import('./commands/swarm.js');
@@ -146,7 +146,7 @@ program
   .argument('<agent-id>', 'Agent ID to restart')
   .option('-p, --prompt <text>', 'Override the original prompt')
   .option('-a, --agent <type>', 'Override the agent type')
-  .option('--no-open', 'Do not open a Terminal window')
+  .option('--open', 'Open a Terminal window for the restarted agent')
   .option('--json', 'Output as JSON')
   .action(async (agentId, options) => {
     const { restartCommand } = await import('./commands/restart.js');

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -104,8 +104,8 @@ export async function restartCommand(agentRef: string, options: RestartOptions):
     return m;
   });
 
-  // Fire-and-forget terminal open
-  if (options.open !== false) {
+  // Only open Terminal window when explicitly requested via --open (fire-and-forget)
+  if (options.open === true) {
     openTerminalWindow(manifest.sessionName, windowTarget, `${wt.name}-restart`).catch(() => {});
   }
 

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -190,8 +190,8 @@ async function spawnNewWorktree(
     return m;
   });
 
-  // Auto-open Terminal window unless --no-open (fire-and-forget)
-  if (options.open !== false) {
+  // Only open Terminal window when explicitly requested via --open (fire-and-forget)
+  if (options.open === true) {
     openTerminalWindow(sessionName, windowTarget, name).catch(() => {});
   }
 
@@ -301,8 +301,8 @@ async function spawnIntoExistingWorktree(
     return m;
   });
 
-  // Auto-open Terminal window unless --no-open (fire-and-forget)
-  if (options.open !== false) {
+  // Only open Terminal window when explicitly requested via --open (fire-and-forget)
+  if (options.open === true) {
     openTerminalWindow(manifest.sessionName, windowTarget, wt.name).catch(() => {});
   }
 

--- a/src/commands/swarm.ts
+++ b/src/commands/swarm.ts
@@ -171,7 +171,7 @@ async function swarmShared(
     });
   }
 
-  if (options.open !== false) {
+  if (options.open === true) {
     openTerminalWindow(sessionName, windowTarget, name).catch(() => {});
   }
 
@@ -236,7 +236,7 @@ async function swarmIsolated(
       return m;
     });
 
-    if (options.open !== false) {
+    if (options.open === true) {
       openTerminalWindow(sessionName, windowTarget, wtName).catch(() => {});
     }
 
@@ -309,7 +309,7 @@ async function swarmIntoExistingWorktree(
     });
   }
 
-  if (options.open !== false) {
+  if (options.open === true) {
     openTerminalWindow(sessionName, windowTarget, wt.name).catch(() => {});
   }
 


### PR DESCRIPTION
## Summary
- Changed `--no-open` (opt-out) to `--open` (opt-in) for spawn, restart, and swarm commands so Terminal.app is never opened unless explicitly requested
- Added exact tmux session name matching (`=` prefix) in `sessionExists`, `createWindow`, `listSessionPanes`, and `attachSession` to prevent windows from being created in grouped/dashboard sessions instead of the main ppg session

## Test plan
- [ ] Run `ppg restart <agent-id>` — should NOT open Terminal.app, should create window in main ppg session
- [ ] Run `ppg spawn --name test --prompt 'hello'` — should NOT open Terminal.app  
- [ ] Run `ppg spawn --name test --prompt 'hello' --open` — SHOULD open Terminal.app
- [ ] Verify tmux windows are created in the correct session when dashboard grouped sessions exist