### PR TITLE
Fix stale sidebar node model data when contentSignature unchanged

### DIFF
--- a/PPG CLI/PPG CLI/SidebarViewController.swift
+++ b/PPG CLI/PPG CLI/SidebarViewController.swift
@@ -553,9 +553,13 @@ class SidebarViewController: NSViewController, NSOutlineViewDataSource, NSOutlin
         for newNode in newChildren {
             guard let oldNode = oldMap[newNode.item.id] else { continue }
 
-            // Update the SidebarItem in-place if content changed
-            if oldNode.item.contentSignature != newNode.item.contentSignature {
-                oldNode.item = newNode.item
+            // Always keep the backing model fresh (non-visual fields like
+            // tmuxTarget / sessionId may change without affecting the signature)
+            let oldSig = oldNode.item.contentSignature
+            oldNode.item = newNode.item
+
+            // Only reload the cell view when visible content changed
+            if oldSig != newNode.item.contentSignature {
                 outlineView.reloadItem(oldNode, reloadChildren: false)
             }
 


### PR DESCRIPTION
## Summary
- Always update the backing `SidebarItem` in the incremental diff so non-visual fields (`tmuxTarget`, `sessionId`) stay fresh
- Only conditionally reload the cell view when `contentSignature` actually changed, preserving the no-flicker optimization from PR #22

## Problem
The incremental diff code in `diffChildren` only updated `oldNode.item` when `contentSignature` changed. Fields not included in `contentSignature` (like `tmuxTarget` on `.terminal` items, or `sessionId` on `.agent` items) could become stale indefinitely, causing broken terminal attachment or wrong session routing when the user selected a reused node.

## Fix
Save the old signature before updating, then always assign the new item, and only call `reloadItem` when the signature differs.

## Test plan
- [ ] Verify sidebar does not flicker on refresh (cell reload still gated on signature change)
- [ ] Verify non-visual fields are fresh after manifest update (e.g., selecting an agent node routes to the correct session)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar item update efficiency by reducing unnecessary UI reloads while ensuring all item data remains properly synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->