### PR TITLE
spawn-safety

### DIFF
--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -121,6 +121,25 @@ async function spawnNewWorktree(
   // Create tmux window
   const windowTarget = await tmux.createWindow(sessionName, name, wtPath);
 
+  // Register skeleton worktree in manifest before spawning agents
+  // so partial failures leave a record for cleanup
+  const worktreeEntry: WorktreeEntry = {
+    id: wtId,
+    name,
+    path: wtPath,
+    branch: branchName,
+    baseBranch,
+    status: 'active',
+    tmuxWindow: windowTarget,
+    agents: {},
+    createdAt: new Date().toISOString(),
+  };
+
+  await updateManifest(projectRoot, (m) => {
+    m.worktrees[wtId] = worktreeEntry;
+    return m;
+  });
+
   // Spawn agents — one tmux window per agent (default), or split panes (--split)
   const agents: AgentEntry[] = [];
   for (let i = 0; i < count; i++) {
@@ -171,25 +190,15 @@ async function spawnNewWorktree(
     });
 
     agents.push(agentEntry);
+
+    // Update manifest incrementally after each agent spawn
+    await updateManifest(projectRoot, (m) => {
+      if (m.worktrees[wtId]) {
+        m.worktrees[wtId].agents[agentEntry.id] = agentEntry;
+      }
+      return m;
+    });
   }
-
-  // Update manifest
-  const worktreeEntry: WorktreeEntry = {
-    id: wtId,
-    name,
-    path: wtPath,
-    branch: branchName,
-    baseBranch,
-    status: 'active',
-    tmuxWindow: windowTarget,
-    agents: Object.fromEntries(agents.map((a) => [a.id, a])),
-    createdAt: new Date().toISOString(),
-  };
-
-  await updateManifest(projectRoot, (m) => {
-    m.worktrees[wtId] = worktreeEntry;
-    return m;
-  });
 
   // Only open Terminal window when explicitly requested via --open (fire-and-forget)
   if (options.open === true) {
@@ -293,6 +302,7 @@ async function spawnIntoExistingWorktree(
 
   await updateManifest(projectRoot, (m) => {
     const mWt = m.worktrees[wt.id];
+    if (!mWt) return m;
     if (!mWt.tmuxWindow) {
       mWt.tmuxWindow = windowTarget;
     }


### PR DESCRIPTION
## Summary

Makes `spawnNewWorktree` crash-safe by registering a skeleton worktree entry in the manifest **before** the agent spawn loop, then updating it incrementally after each successful agent spawn. This ensures partial failures leave a record for cleanup via `ppg clean` or `ppg kill`.

### Changes

- **Pre-register skeleton worktree** — Write the worktree entry (with empty `agents: {}`) to the manifest immediately after creating the git worktree and tmux window, before spawning any agents.
- **Incremental agent persistence** — Each successfully spawned agent is persisted to the manifest immediately, replacing the previous bulk write that happened only after all agents finished.
- **Null guard in `spawnIntoExistingWorktree`** — Added `if (!mWt) return m;` to handle the edge case where a worktree was removed between manifest read and update.

### Tradeoffs

- Trades more manifest writes (one per agent vs one bulk) for crash safety. Given typical agent counts (1–5), the overhead is negligible.
- If a failure occurs mid-loop (e.g., agent 2 of 3 fails), the manifest retains the worktree + agents spawned so far, enabling cleanup of orphaned resources.

### Validation

- `npm run typecheck` — clean
- `npm test` — 105 tests passing
- `npm run build` — clean
- CI: all checks green (test node 20, test node 22, CodeRabbit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)