### PR TITLE
shell-safety

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -76,12 +76,14 @@ function buildAgentCommand(agentConfig: AgentConfig, promptFilePath: string, ses
   const { command, promptFlag } = agentConfig;
   // Inject --session-id for Claude-based commands
   const sessionFlag = sessionId && command.includes('claude') ? ` --session-id ${sessionId}` : '';
+  // Single-quote the path inside $(cat ...) to handle spaces safely
+  const catExpr = `"$(cat '${promptFilePath}')"`;
   if (promptFlag) {
-    // Use explicit flag: command --flag "$(cat prompt-file)"
-    return `${envPrefix} ${command}${sessionFlag} ${promptFlag} "$(cat ${promptFilePath})"`;
+    // Use explicit flag: command --flag "$(cat 'prompt-file')"
+    return `${envPrefix} ${command}${sessionFlag} ${promptFlag} ${catExpr}`;
   }
-  // Pass prompt as positional argument: command "$(cat prompt-file)"
-  return `${envPrefix} ${command}${sessionFlag} "$(cat ${promptFilePath})"`;
+  // Pass prompt as positional argument: command "$(cat 'prompt-file')"
+  return `${envPrefix} ${command}${sessionFlag} ${catExpr}`;
 }
 
 /**

--- a/src/core/terminal.ts
+++ b/src/core/terminal.ts
@@ -1,5 +1,6 @@
 import { execa } from 'execa';
 import { warn } from '../lib/output.js';
+import { shellEscape } from '../lib/shell.js';
 
 /**
  * Open a new Terminal.app window that attaches to a specific tmux session/window.
@@ -11,13 +12,17 @@ export async function openTerminalWindow(
 ): Promise<void> {
   // Source shell profiles so tmux is found on M-series Macs where
   // /opt/homebrew/bin is not in the default GUI app / Terminal.app PATH.
-  const tmuxCmd = `if [ -x /usr/libexec/path_helper ]; then eval $(/usr/libexec/path_helper -s); fi; [ -f ~/.zprofile ] && source ~/.zprofile; [ -f ~/.zshrc ] && source ~/.zshrc; tmux attach-session -t ${sessionName} \\\\; select-window -t ${windowTarget}`;
+  // Escape values for safe interpolation inside AppleScript double-quoted strings.
+  const safeSession = shellEscape(sessionName);
+  const safeWindow = shellEscape(windowTarget);
+  const safeTitle = shellEscape(title);
+  const tmuxCmd = `if [ -x /usr/libexec/path_helper ]; then eval $(/usr/libexec/path_helper -s); fi; [ -f ~/.zprofile ] && source ~/.zprofile; [ -f ~/.zshrc ] && source ~/.zshrc; tmux attach-session -t ${safeSession} \\\\; select-window -t ${safeWindow}`;
 
   const script = `
 tell application "Terminal"
   activate
   set newTab to do script "${tmuxCmd}"
-  set custom title of newTab to "${title}"
+  set custom title of newTab to "${safeTitle}"
 end tell
 `;
 


### PR DESCRIPTION
## Summary

Fix shell and AppleScript interpolation safety issues to prevent breakage from paths/names containing spaces or special characters.

### Changes

- **`src/core/agent.ts`** — In `buildAgentCommand`, wrapped `promptFilePath` in single quotes inside the `$(cat ...)` subshell expression. Paths with spaces no longer break the shell command.
- **`src/core/terminal.ts`** — Imported `shellEscape` from `../lib/shell.js` and applied it to `sessionName`, `windowTarget`, and `title` before interpolating them into the AppleScript double-quoted strings. This escapes `\`, `"`, `$`, and backticks — exactly the characters that could cause injection or breakage in AppleScript string literals.

### Rationale

- The `agent.ts` fix uses single quotes rather than `shellEscape` because the path is inside a `$(cat ...)` subshell — single quoting is the correct shell idiom for literal paths there (prevents word splitting and glob expansion).
- The `shellEscape` utility already existed in `src/lib/shell.ts` and handles the exact characters needed for AppleScript double-quoted string safety.

### Validation

- `npm run typecheck` — clean
- `npm test` — 105 tests passing
- `npm run build` — success
- CI checks all green (node 20, node 22)