### PR TITLE
restart-prompt

### DIFF
--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -88,6 +88,7 @@ export async function restartCommand(agentRef: string, options: RestartOptions):
     projectRoot,
     branch: wt.branch,
     sessionId: newSessionId,
+    skipResultInstructions: !options.prompt,
   });
 
   // Update manifest: mark old agent as killed, add new agent

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -19,6 +19,7 @@ export interface SpawnAgentOptions {
   projectRoot: string;
   branch: string;
   sessionId?: string;
+  skipResultInstructions?: boolean;
 }
 
 export async function spawnAgent(options: SpawnAgentOptions): Promise<AgentEntry> {
@@ -36,7 +37,7 @@ export async function spawnAgent(options: SpawnAgentOptions): Promise<AgentEntry
 
   // Build full prompt with result instructions
   let fullPrompt = prompt;
-  if (agentConfig.resultInstructions) {
+  if (agentConfig.resultInstructions && !options.skipResultInstructions) {
     const ctx: TemplateContext = {
       WORKTREE_PATH: worktreePath,
       BRANCH: branch,


### PR DESCRIPTION
## Summary

Fix restart command double-appending `resultInstructions` to the prompt file.

When restarting an agent without a new `--prompt`, the existing prompt file already contains the rendered `resultInstructions` from the original spawn. The `spawnAgent` function was appending them again, causing duplication on every restart.

## Changes

- **`src/core/agent.ts`** — Added `skipResultInstructions?: boolean` to `SpawnAgentOptions` interface; guarded `resultInstructions` append with `&& !options.skipResultInstructions`
- **`src/commands/restart.ts`** — Pass `skipResultInstructions: !options.prompt` to `spawnAgent` so instructions are skipped when reusing the existing prompt file, but still appended when a new `--prompt` is provided

## How to validate

1. `ppg spawn --name test --prompt "do something"` — verify result instructions appear once in the prompt file
2. `ppg restart <agent>` (no new prompt) — verify result instructions are NOT duplicated
3. `ppg restart <agent> --prompt "new task"` — verify result instructions appear once (appended to the new prompt)

## Checks

- 105 tests pass
- Typecheck clean
- Build successful