### PR TITLE
kill-status

### DIFF
--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -90,6 +90,15 @@ async function killSingleAgent(
       success(`Deleted agent ${agentId}`);
     }
   } else {
+    if (isTerminal) {
+      if (options.json) {
+        output({ success: true, killed: [], message: `Agent ${agentId} already ${agent.status}` }, true);
+      } else {
+        info(`Agent ${agentId} already ${agent.status}, skipping kill`);
+      }
+      return;
+    }
+
     info(`Killing agent ${agentId}`);
     await killAgent(agent);
 


### PR DESCRIPTION
## Summary

Adds a terminal-status guard to `killSingleAgent` so that agents already in a terminal state (`completed`, `failed`, `killed`, `lost`) are not overwritten to `killed` when using `ppg kill --agent`.

**Before**: Running `ppg kill --agent <id>` on an already-completed agent would overwrite its status to `killed` and set a new `completedAt` timestamp, losing the original completion information.

**After**: The command detects the terminal state and returns early with an informational message, preserving the original status and timestamp.

## Changes

- `src/commands/kill.ts`: Added `isTerminal` check in the non-delete branch (line 93). When an agent is already terminal, outputs an info message and returns early without modifying the manifest.
  - JSON output: `{ success: true, killed: [], message: "Agent <id> already <status>" }`
  - Text output: `Agent <id> already <status>, skipping kill`

## How to validate

1. `npm run typecheck` — passes
2. `npm test` — 105 tests passing
3. `npm run build` — builds successfully
4. CI checks: all green (Node 20, Node 22)