### PR TITLE
init-config

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
-import { pgDir, resultsDir, logsDir, templatesDir, promptsDir, promptFile, swarmsDir, manifestPath, agentPromptsDir } from '../lib/paths.js';
+import { pgDir, resultsDir, logsDir, templatesDir, promptsDir, promptFile, swarmsDir, manifestPath, agentPromptsDir, configPath } from '../lib/paths.js';
 import { NotGitRepoError } from '../lib/errors.js';
 import { success, info } from '../lib/output.js';
 import { writeDefaultConfig } from '../core/config.js';
@@ -90,9 +90,15 @@ export async function initCommand(options: { json?: boolean }): Promise<void> {
 
   info('Created .pg/ directory structure');
 
-  // 4. Write default config
-  await writeDefaultConfig(projectRoot);
-  info('Wrote default config.yaml');
+  // 4. Write default config (skip if exists)
+  const cfgPath = configPath(projectRoot);
+  try {
+    await fs.access(cfgPath);
+    info('config.yaml already exists, skipping');
+  } catch {
+    await writeDefaultConfig(projectRoot);
+    info('Wrote default config.yaml');
+  }
 
   // 5. Write empty manifest
   const dirName = path.basename(projectRoot);


### PR DESCRIPTION
## Summary

Fixes `ppg init` to preserve existing `config.yaml` instead of overwriting it on re-init.

**Problem:** Running `ppg init` in an already-initialized project would overwrite any user customizations in `.pg/config.yaml` with defaults.

**Fix:** Added an existence check before writing default config — if `config.yaml` already exists, the init command now skips it and logs a message. This matches the existing pattern used for templates and prompts in the same file.

## Changes

- `src/commands/init.ts` — Added `configPath` import; replaced unconditional `writeDefaultConfig()` with `fs.access` guard that skips if config already exists.

## Validation

- `npm run typecheck` — passes
- `npm test` — 105 tests pass
- `npm run build` — builds successfully
- CI checks all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)