### PR TITLE
config-merge

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -52,13 +52,20 @@ export async function loadConfig(projectRoot: string): Promise<Config> {
 }
 
 function mergeConfig(defaults: Config, overrides: Partial<Config>): Config {
+  const mergedAgents: Record<string, AgentConfig> = { ...defaults.agents };
+  if (overrides.agents) {
+    for (const [key, override] of Object.entries(overrides.agents)) {
+      if (mergedAgents[key]) {
+        mergedAgents[key] = { ...mergedAgents[key], ...override };
+      } else {
+        mergedAgents[key] = override;
+      }
+    }
+  }
   return {
     ...defaults,
     ...overrides,
-    agents: {
-      ...defaults.agents,
-      ...(overrides.agents ?? {}),
-    },
+    agents: mergedAgents,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixed `mergeConfig` in `src/core/config.ts` to deep-merge individual agent configs instead of shallow-spreading the entire agents object.

Previously, a partial override like `{ agents: { claude: { command: "..." } } }` would replace the entire `claude` agent entry, dropping required fields like `name`, `interactive`, and `resultInstructions`. Now each agent's properties are merged individually, preserving defaults for unspecified fields.

## Changes

- `src/core/config.ts` — Rewrote `mergeConfig` to iterate over override agents and spread them into existing defaults per-key, rather than replacing at the top level.

## Validation

- `npm run typecheck` — pass
- `npm test` — 105 tests passing
- `npm run build` — success
- CI (Node 20 + 22) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)