### PR TITLE
json-errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,8 @@ const program = new Command();
 program
   .name('ppg')
   .description('Pure Point Guard — local orchestration runtime for parallel CLI coding agents')
-  .version(pkg.version);
+  .version(pkg.version)
+  .option('--json', 'Output as JSON');
 
 program
   .command('init')
@@ -280,7 +281,7 @@ async function main() {
         process.exit(0);
       }
     }
-    outputError(err, false);
+    outputError(err, program.opts().json ?? false);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes global error handler to output JSON-formatted errors when `--json` flag is passed to any subcommand.

**Problem**: The global `catch` in `main()` always called `outputError(err, false)` because `--json` was only defined on individual subcommands. `program.opts().json` was always `undefined`, so errors like invalid arguments or unknown commands always produced plain-text output — even when `--json` was explicitly passed.

**Fix**: Added `--json` as a global option on the Commander.js program. The global error handler now reads `program.opts().json ?? false` to determine output format. Per-subcommand `--json` options continue to work as before (Commander.js propagates options upward).

## Changes
- `src/cli.ts`: Added `.option('--json', 'Output as JSON')` to the program definition and updated the fallback error handler to use `program.opts().json ?? false`

## Validation
- All 105 tests pass
- Typecheck clean (`tsc --noEmit`)
- Build succeeds (`tsup`)
- CI checks green (Node 20, Node 22, CodeRabbit)