### PR TITLE
manifest-errors

### DIFF
--- a/src/commands/aggregate.ts
+++ b/src/commands/aggregate.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
-import { readManifest, resolveWorktree, updateManifest } from '../core/manifest.js';
+import { requireManifest, resolveWorktree, updateManifest } from '../core/manifest.js';
 import { refreshAllAgentStatuses } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
 import * as tmux from '../core/tmux.js';
-import { NotInitializedError, WorktreeNotFoundError } from '../lib/errors.js';
+import { WorktreeNotFoundError } from '../lib/errors.js';
 import { output, success, warn } from '../lib/output.js';
 import type { AgentEntry, WorktreeEntry } from '../types/manifest.js';
 
@@ -19,14 +19,10 @@ export async function aggregateCommand(
 ): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await updateManifest(projectRoot, async (m) => {
-      return refreshAllAgentStatuses(m, projectRoot);
-    });
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  await requireManifest(projectRoot);
+  const manifest = await updateManifest(projectRoot, async (m) => {
+    return refreshAllAgentStatuses(m, projectRoot);
+  });
 
   let worktrees: WorktreeEntry[];
 

--- a/src/commands/attach.ts
+++ b/src/commands/attach.ts
@@ -1,22 +1,17 @@
-import { readManifest, resolveWorktree, findAgent } from '../core/manifest.js';
+import { requireManifest, resolveWorktree, findAgent } from '../core/manifest.js';
 import { getRepoRoot } from '../core/worktree.js';
 import { getPaneInfo } from '../core/tmux.js';
 import { resumeAgent } from '../core/agent.js';
 import * as tmux from '../core/tmux.js';
 import { openTerminalWindow } from '../core/terminal.js';
-import { PgError, NotInitializedError } from '../lib/errors.js';
+import { PgError } from '../lib/errors.js';
 import { info, success } from '../lib/output.js';
 import type { AgentEntry } from '../types/manifest.js';
 
 export async function attachCommand(target: string): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   // Try to resolve target as worktree ID, worktree name, or agent ID
   let tmuxTarget: string | undefined;

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,9 +1,8 @@
-import { readManifest, updateManifest } from '../core/manifest.js';
+import { requireManifest, updateManifest } from '../core/manifest.js';
 import { getRepoRoot, pruneWorktrees } from '../core/worktree.js';
 import { cleanupWorktree } from '../core/cleanup.js';
 import { getCurrentPaneId, wouldCleanupAffectSelf } from '../core/self.js';
 import { listSessionPanes, type PaneInfo } from '../core/tmux.js';
-import { NotInitializedError } from '../lib/errors.js';
 import { output, success, info, warn } from '../lib/output.js';
 import type { WorktreeEntry } from '../types/manifest.js';
 
@@ -17,12 +16,7 @@ export interface CleanOptions {
 export async function cleanCommand(options: CleanOptions): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   // Build self-protection context if inside tmux
   const selfPaneId = getCurrentPaneId();

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa';
-import { readManifest, resolveWorktree } from '../core/manifest.js';
+import { requireManifest, resolveWorktree } from '../core/manifest.js';
 import { getRepoRoot } from '../core/worktree.js';
-import { NotInitializedError, WorktreeNotFoundError } from '../lib/errors.js';
+import { WorktreeNotFoundError } from '../lib/errors.js';
 import { output } from '../lib/output.js';
 import { execaEnv } from '../lib/env.js';
 
@@ -14,12 +14,7 @@ export interface DiffOptions {
 export async function diffCommand(worktreeRef: string, options: DiffOptions): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   const wt = resolveWorktree(manifest, worktreeRef);
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,7 +1,7 @@
-import { readManifest, findAgent } from '../core/manifest.js';
+import { requireManifest, findAgent } from '../core/manifest.js';
 import { getRepoRoot } from '../core/worktree.js';
 import * as tmux from '../core/tmux.js';
-import { PgError, NotInitializedError, AgentNotFoundError } from '../lib/errors.js';
+import { PgError, AgentNotFoundError } from '../lib/errors.js';
 import { output, outputError } from '../lib/output.js';
 
 export interface LogsOptions {
@@ -14,12 +14,7 @@ export interface LogsOptions {
 export async function logsCommand(agentId: string, options: LogsOptions): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   const found = findAgent(manifest, agentId);
   if (!found) throw new AgentNotFoundError(agentId);

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -1,11 +1,11 @@
 import { execa } from 'execa';
-import { readManifest, updateManifest, resolveWorktree } from '../core/manifest.js';
+import { requireManifest, updateManifest, resolveWorktree } from '../core/manifest.js';
 import { refreshAllAgentStatuses } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
 import { cleanupWorktree } from '../core/cleanup.js';
 import { getCurrentPaneId } from '../core/self.js';
 import { listSessionPanes, type PaneInfo } from '../core/tmux.js';
-import { PgError, NotInitializedError, WorktreeNotFoundError, MergeFailedError } from '../lib/errors.js';
+import { PgError, WorktreeNotFoundError, MergeFailedError } from '../lib/errors.js';
 import { output, success, info, warn } from '../lib/output.js';
 import { execaEnv } from '../lib/env.js';
 
@@ -20,14 +20,10 @@ export interface MergeOptions {
 export async function mergeCommand(worktreeId: string, options: MergeOptions): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await updateManifest(projectRoot, async (m) => {
-      return refreshAllAgentStatuses(m, projectRoot);
-    });
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  await requireManifest(projectRoot);
+  const manifest = await updateManifest(projectRoot, async (m) => {
+    return refreshAllAgentStatuses(m, projectRoot);
+  });
 
   const wt = resolveWorktree(manifest, worktreeId);
 

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import { readManifest, updateManifest, findAgent } from '../core/manifest.js';
+import { requireManifest, updateManifest, findAgent } from '../core/manifest.js';
 import { loadConfig, resolveAgentConfig } from '../core/config.js';
 import { spawnAgent, killAgent } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
@@ -7,7 +7,7 @@ import * as tmux from '../core/tmux.js';
 import { openTerminalWindow } from '../core/terminal.js';
 import { agentId as genAgentId, sessionId as genSessionId } from '../lib/id.js';
 import { agentPromptFile, resultFile } from '../lib/paths.js';
-import { PgError, NotInitializedError, AgentNotFoundError } from '../lib/errors.js';
+import { PgError, AgentNotFoundError } from '../lib/errors.js';
 import { output, success, info } from '../lib/output.js';
 import { renderTemplate, type TemplateContext } from '../core/template.js';
 
@@ -22,12 +22,7 @@ export async function restartCommand(agentRef: string, options: RestartOptions):
   const projectRoot = await getRepoRoot();
   const config = await loadConfig(projectRoot);
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   const found = findAgent(manifest, agentRef);
   if (!found) throw new AgentNotFoundError(agentRef);

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,7 +1,7 @@
-import { readManifest, findAgent } from '../core/manifest.js';
+import { requireManifest, findAgent } from '../core/manifest.js';
 import { getRepoRoot } from '../core/worktree.js';
 import * as tmux from '../core/tmux.js';
-import { NotInitializedError, AgentNotFoundError } from '../lib/errors.js';
+import { AgentNotFoundError } from '../lib/errors.js';
 import { output, success } from '../lib/output.js';
 
 export interface SendOptions {
@@ -13,12 +13,7 @@ export interface SendOptions {
 export async function sendCommand(agentId: string, text: string, options: SendOptions): Promise<void> {
   const projectRoot = await getRepoRoot();
 
-  let manifest;
-  try {
-    manifest = await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  const manifest = await requireManifest(projectRoot);
 
   const found = findAgent(manifest, agentId);
   if (!found) throw new AgentNotFoundError(agentId);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,8 +1,7 @@
 import { loadConfig } from '../core/config.js';
-import { readManifest, updateManifest } from '../core/manifest.js';
+import { requireManifest, updateManifest } from '../core/manifest.js';
 import { refreshAllAgentStatuses } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
-import { NotInitializedError } from '../lib/errors.js';
 import { output, formatStatus, formatTable, type Column } from '../lib/output.js';
 import type { AgentEntry, WorktreeEntry } from '../types/manifest.js';
 
@@ -16,14 +15,10 @@ export async function statusCommand(worktreeFilter?: string, options?: StatusOpt
   const projectRoot = await getRepoRoot();
 
   // Read manifest and refresh statuses
-  let manifest;
-  try {
-    manifest = await updateManifest(projectRoot, async (m) => {
-      return refreshAllAgentStatuses(m, projectRoot);
-    });
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  await requireManifest(projectRoot);
+  const manifest = await updateManifest(projectRoot, async (m) => {
+    return refreshAllAgentStatuses(m, projectRoot);
+  });
 
   // Filter worktrees if specified
   const filter = worktreeFilter ?? options?.worktree;

--- a/src/commands/wait.ts
+++ b/src/commands/wait.ts
@@ -1,7 +1,7 @@
-import { updateManifest, resolveWorktree } from '../core/manifest.js';
+import { requireManifest, updateManifest, resolveWorktree } from '../core/manifest.js';
 import { refreshAllAgentStatuses } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
-import { PgError, NotInitializedError, WorktreeNotFoundError } from '../lib/errors.js';
+import { PgError, WorktreeNotFoundError } from '../lib/errors.js';
 import { output, info } from '../lib/output.js';
 import type { AgentEntry, AgentStatus, Manifest } from '../types/manifest.js';
 
@@ -72,13 +72,10 @@ export async function waitCommand(worktreeRef: string | undefined, options: Wait
 }
 
 async function refreshAndGet(projectRoot: string): Promise<Manifest> {
-  try {
-    return await updateManifest(projectRoot, async (m) => {
-      return refreshAllAgentStatuses(m, projectRoot);
-    });
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  await requireManifest(projectRoot);
+  return await updateManifest(projectRoot, async (m) => {
+    return refreshAllAgentStatuses(m, projectRoot);
+  });
 }
 
 function collectAgents(

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,9 +1,8 @@
 import { loadConfig } from '../core/config.js';
-import { readManifest, updateManifest } from '../core/manifest.js';
+import { requireManifest, updateManifest } from '../core/manifest.js';
 import { getRepoRoot, getCurrentBranch, createWorktree } from '../core/worktree.js';
 import { setupWorktreeEnv } from '../core/env.js';
 import { worktreeId as genWorktreeId } from '../lib/id.js';
-import { NotInitializedError } from '../lib/errors.js';
 import { output, success, info } from '../lib/output.js';
 import { normalizeName } from '../lib/name.js';
 import type { WorktreeEntry } from '../types/manifest.js';
@@ -19,11 +18,7 @@ export async function worktreeCreateCommand(options: WorktreeCreateOptions): Pro
   const config = await loadConfig(projectRoot);
 
   // Verify initialized
-  try {
-    await readManifest(projectRoot);
-  } catch {
-    throw new NotInitializedError(projectRoot);
-  }
+  await requireManifest(projectRoot);
 
   const baseBranch = options.base ?? await getCurrentBranch(projectRoot);
   const wtId = genWorktreeId();


### PR DESCRIPTION
## Summary

Adds a `requireManifest` helper to `src/core/manifest.ts` that only converts ENOENT errors to `NotInitializedError`, letting all other errors (corrupt JSON, permission errors, lock contention) propagate with their original type. Replaces all 11 occurrences of the overly-broad `try { readManifest/updateManifest } catch { throw NotInitializedError }` pattern across command files.

## Changes

- **src/core/manifest.ts** — Added `requireManifest()` that reads the manifest, converting only ENOENT → `NotInitializedError`
- **11 command files** — Replaced try/catch blocks with `requireManifest` calls:
  `status`, `aggregate`, `merge`, `clean`, `logs`, `send`, `diff`, `restart`, `wait`, `attach`, `worktree`

## How to validate

```bash
npm run typecheck  # clean
npm test           # 105 tests pass
npm run build      # success
```

For commands that previously swallowed all errors as "not initialized", corrupt JSON or permission errors now surface with their original messages instead of the misleading "ppg has not been initialized" error.