### PR TITLE
config-paths

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -29,10 +29,6 @@ const DEFAULT_CONFIG: Config = {
       ].join('\n'),
     },
   },
-  worktreeBase: '.worktrees',
-  templateDir: '.pg/templates',
-  resultDir: '.pg/results',
-  logDir: '.pg/logs',
   envFiles: ['.env', '.env.local'],
   symlinkNodeModules: true,
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,10 +11,6 @@ export interface Config {
   sessionName: string;
   defaultAgent: string;
   agents: Record<string, AgentConfig>;
-  worktreeBase: string;
-  templateDir: string;
-  resultDir: string;
-  logDir: string;
   envFiles: string[];
   symlinkNodeModules: boolean;
 }


### PR DESCRIPTION
## Summary

Remove unused config path fields (`worktreeBase`, `templateDir`, `resultDir`, `logDir`) from the `Config` interface and `DEFAULT_CONFIG`.

These fields were never consumed — all path computation is hardcoded in `src/lib/paths.ts`. Removing them eliminates dead configuration surface area.

## Changes

- **`src/types/config.ts`** — Removed `worktreeBase`, `templateDir`, `resultDir`, `logDir` from `Config` interface
- **`src/core/config.ts`** — Removed corresponding default values from `DEFAULT_CONFIG`

## Validation

- `npm run typecheck` — passes
- `npm test` — 105 tests pass
- `npm run build` — clean build
- Confirmed no code references these removed fields (only the two changed files)