### PR TITLE
Rename .pg to .ppg across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,10 @@ src/
 |---------|-------------|
 | **Worktree** | Isolated git checkout on branch `ppg/<name>`, lives in `.worktrees/wt-{id}/` |
 | **Agent** | CLI process in a tmux pane, receives task via prompt file |
-| **Manifest** | `.pg/manifest.json` — runtime state: worktrees, agents, statuses, tmux targets |
-| **Config** | `.pg/config.yaml` — session name, agent definitions, directory paths |
-| **Template** | Markdown in `.pg/templates/` with `{{VAR}}` placeholders |
-| **Result file** | `.pg/results/{agentId}.md` — primary agent completion signal |
+| **Manifest** | `.ppg/manifest.json` — runtime state: worktrees, agents, statuses, tmux targets |
+| **Config** | `.ppg/config.yaml` — session name, agent definitions, directory paths |
+| **Template** | Markdown in `.ppg/templates/` with `{{VAR}}` placeholders |
+| **Result file** | `.ppg/results/{agentId}.md` — primary agent completion signal |
 
 ## Agent Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Each `ppg spawn` creates a git worktree on a `ppg/<name>` branch, opens a tmux p
 
 ```
 your-project/
-├── .pg/
+├── .ppg/
 │   ├── config.yaml      # Agent and project config
 │   ├── manifest.json     # Runtime state (worktrees, agents, status)
 │   ├── templates/        # Reusable prompt templates
@@ -118,7 +118,7 @@ spawning → running → completed   (result file written)
 
 ## Configuration
 
-`.pg/config.yaml`:
+`.ppg/config.yaml`:
 
 ```yaml
 sessionName: ppg
@@ -146,9 +146,9 @@ agents:
     interactive: false
 
 worktreeBase: .worktrees
-templateDir: .pg/templates
-resultDir: .pg/results
-logDir: .pg/logs
+templateDir: .ppg/templates
+resultDir: .ppg/results
+logDir: .ppg/logs
 envFiles:
   - .env
   - .env.local
@@ -157,7 +157,7 @@ symlinkNodeModules: true
 
 ## Templates
 
-Templates live in `.pg/templates/` as Markdown files with `{{VAR}}` placeholders. The prompts editor in the dashboard lets you create and edit these visually.
+Templates live in `.ppg/templates/` as Markdown files with `{{VAR}}` placeholders. The prompts editor in the dashboard lets you create and edit these visually.
 
 **Built-in variables:** `{{WORKTREE_PATH}}`, `{{BRANCH}}`, `{{AGENT_ID}}`, `{{RESULT_FILE}}`, `{{PROJECT_ROOT}}`, `{{TASK_NAME}}`, `{{PROMPT}}`
 

--- a/skills/ppg-conductor/references/commands.md
+++ b/skills/ppg-conductor/references/commands.md
@@ -4,7 +4,7 @@ Quick reference for all ppg commands relevant to conductor workflows. Always use
 
 ## ppg init
 
-Initialize ppg in the current git repository. Creates `.pg/` directory structure, default config, empty manifest, and sample template.
+Initialize ppg in the current git repository. Creates `.ppg/` directory structure, default config, empty manifest, and sample template.
 
 ```bash
 ppg init --json
@@ -12,7 +12,7 @@ ppg init --json
 
 **JSON output:**
 ```json
-{ "success": true, "projectRoot": "/path/to/repo", "sessionName": "ppg-repo", "pgDir": "/path/to/repo/.pg" }
+{ "success": true, "projectRoot": "/path/to/repo", "sessionName": "ppg-repo", "pgDir": "/path/to/repo/.ppg" }
 ```
 
 **Errors:** `NOT_GIT_REPO`, `TMUX_NOT_FOUND`
@@ -49,7 +49,7 @@ ppg spawn --name <name> --prompt-file /path/to/prompt.md --json --no-open
 | `-a, --agent <type>` | Agent type from config (default: `claude`) |
 | `-p, --prompt <text>` | Inline prompt text |
 | `-f, --prompt-file <path>` | Path to file containing prompt |
-| `-t, --template <name>` | Template name from `.pg/templates/` |
+| `-t, --template <name>` | Template name from `.ppg/templates/` |
 | `--var <KEY=value>` | Template variable (repeatable) |
 | `-b, --base <branch>` | Base branch (default: current branch) |
 | `-w, --worktree <id>` | Add agent to existing worktree instead of creating new one |
@@ -109,7 +109,7 @@ ppg status --watch                   # Live-refresh in terminal
           "status": "running",
           "tmuxTarget": "ppg-repo:1",
           "prompt": "...",
-          "resultFile": "/path/.pg/results/ag-xyz12345.md",
+          "resultFile": "/path/.ppg/results/ag-xyz12345.md",
           "startedAt": "2025-01-01T00:00:00.000Z"
         }
       },
@@ -166,7 +166,7 @@ ppg aggregate <worktree-id> --json      # Specific worktree
 }
 ```
 
-Results come from `.pg/results/<agentId>.md`. If no result file exists, falls back to tmux pane capture.
+Results come from `.ppg/results/<agentId>.md`. If no result file exists, falls back to tmux pane capture.
 
 ## ppg pr
 
@@ -269,7 +269,7 @@ Cleanup sequence: kill tmux window, teardown env, `git worktree remove --force`,
 
 ## ppg swarm
 
-Run a predefined swarm template — spawns multiple agents from `.pg/swarms/` with prompts from `.pg/prompts/`.
+Run a predefined swarm template — spawns multiple agents from `.ppg/swarms/` with prompts from `.ppg/prompts/`.
 
 ```bash
 # Run a swarm template (creates new worktree, spawns all agents)
@@ -487,7 +487,7 @@ ppg attach <agent-id>                   # Attach to agent's tmux pane
 |------|---------|----------|
 | `TMUX_NOT_FOUND` | tmux not installed | Fatal — user must install tmux |
 | `NOT_GIT_REPO` | Not inside a git repository | Fatal — user must cd to a repo |
-| `NOT_INITIALIZED` | `.pg/` directory missing | Auto-fix: run `ppg init --json` |
+| `NOT_INITIALIZED` | `.ppg/` directory missing | Auto-fix: run `ppg init --json` |
 | `MANIFEST_LOCK` | Could not acquire manifest lock | Retry after brief delay (rare) |
 | `WORKTREE_NOT_FOUND` | Worktree ID/name not in manifest | Check `ppg status --json` for valid IDs |
 | `AGENT_NOT_FOUND` | Agent ID not in manifest | Check `ppg status --json` for valid IDs |

--- a/skills/ppg-conductor/references/conductor.md
+++ b/skills/ppg-conductor/references/conductor.md
@@ -21,7 +21,7 @@ ppg spawn --name "<name>" --prompt "<self-contained prompt>" --json --no-open
 
 **Store a tracking table** with: worktree ID, agent IDs, name, and branch for each spawned task.
 
-**Swarm templates** — If a matching swarm template exists in `.pg/swarms/`, prefer `ppg swarm` over manual multi-spawn:
+**Swarm templates** — If a matching swarm template exists in `.ppg/swarms/`, prefer `ppg swarm` over manual multi-spawn:
 ```bash
 # Use a predefined swarm template (much simpler than manual spawning)
 ppg swarm code-review --var CONTEXT="Review the auth module" --json --no-open

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ program
   .option('-a, --agent <type>', 'Agent type to use (default: claude)')
   .option('-p, --prompt <text>', 'Prompt text for the agent')
   .option('-f, --prompt-file <path>', 'File containing the prompt')
-  .option('-t, --template <name>', 'Template name from .pg/templates/')
+  .option('-t, --template <name>', 'Template name from .ppg/templates/')
   .option('--var <key=value...>', 'Template variables', collectVars, [])
   .option('-b, --base <branch>', 'Base branch for the worktree')
   .option('-w, --worktree <id>', 'Add agent to existing worktree')
@@ -120,7 +120,7 @@ program
 program
   .command('swarm')
   .description('Run a swarm template — spawn multiple agents from a predefined workflow')
-  .argument('<template>', 'Swarm template name from .pg/swarms/')
+  .argument('<template>', 'Swarm template name from .ppg/swarms/')
   .option('-w, --worktree <ref>', 'Target an existing worktree by ID, name, or branch')
   .option('--var <key=value...>', 'Template variables', collectVars, [])
   .option('-n, --name <name>', 'Override worktree name')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -85,7 +85,7 @@ export async function initCommand(options: { json?: boolean }): Promise<void> {
     await fs.mkdir(dir, { recursive: true });
   }
 
-  info('Created .pg/ directory structure');
+  info('Created .ppg/ directory structure');
 
   // 4. Write default config (skip if exists)
   const cfgPath = configPath(projectRoot);
@@ -215,13 +215,13 @@ async function registerClaudePlugin(): Promise<boolean> {
 async function updateGitignore(projectRoot: string): Promise<void> {
   const gitignorePath = path.join(projectRoot, '.gitignore');
   const entriesToAdd = [
-    '.pg/results/',
-    '.pg/logs/',
-    '.pg/manifest.json',
-    '.pg/prompts/',
-    '.pg/agent-prompts/',
-    '.pg/swarms/',
-    '.pg/conductor-context.md',
+    '.ppg/results/',
+    '.ppg/logs/',
+    '.ppg/manifest.json',
+    '.ppg/prompts/',
+    '.ppg/agent-prompts/',
+    '.ppg/swarms/',
+    '.ppg/conductor-context.md',
   ];
 
   let content = '';

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -27,7 +27,7 @@ async function listTemplatesCommand(options: ListOptions): Promise<void> {
   const templateNames = await listTemplates(projectRoot);
 
   if (templateNames.length === 0) {
-    console.log('No templates found in .pg/templates/');
+    console.log('No templates found in .ppg/templates/');
     return;
   }
 
@@ -74,7 +74,7 @@ async function listSwarmsCommand(options: ListOptions): Promise<void> {
     if (options.json) {
       output({ swarms: [] }, true);
     } else {
-      console.log('No swarm templates found in .pg/swarms/');
+      console.log('No swarm templates found in .ppg/swarms/');
     }
     return;
   }

--- a/src/commands/pr.test.ts
+++ b/src/commands/pr.test.ts
@@ -26,7 +26,7 @@ describe('truncateBody', () => {
 
     expect(result.length).toBeLessThan(body.length);
     expect(result).toContain('[Truncated');
-    expect(result).toContain('.pg/results/');
+    expect(result).toContain('.ppg/results/');
     expect(result.startsWith('x'.repeat(60_000))).toBe(true);
   });
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -116,5 +116,5 @@ export async function buildBodyFromResults(agents: { resultFile: string }[]): Pr
 /** Truncate body to stay within GitHub's PR body size limit. */
 export function truncateBody(body: string): string {
   if (body.length <= MAX_BODY_LENGTH) return body;
-  return body.slice(0, MAX_BODY_LENGTH) + '\n\n---\n\n*[Truncated — full results available in `.pg/results/`]*';
+  return body.slice(0, MAX_BODY_LENGTH) + '\n\n---\n\n*[Truncated — full results available in `.ppg/results/`]*';
 }

--- a/src/commands/swarm.ts
+++ b/src/commands/swarm.ts
@@ -58,7 +58,7 @@ async function loadPromptFile(projectRoot: string, promptName: string): Promise<
   try {
     return await fs.readFile(filePath, 'utf-8');
   } catch {
-    throw new PgError(`Prompt file not found: ${promptName}.md in .pg/prompts/`, 'INVALID_ARGS');
+    throw new PgError(`Prompt file not found: ${promptName}.md in .ppg/prompts/`, 'INVALID_ARGS');
   }
 }
 

--- a/src/core/swarm.test.ts
+++ b/src/core/swarm.test.ts
@@ -9,7 +9,7 @@ let SWARMS_DIR: string;
 
 beforeEach(async () => {
   TMP_ROOT = await fs.mkdtemp(path.join(os.tmpdir(), 'ppg-swarm-test-'));
-  SWARMS_DIR = path.join(TMP_ROOT, '.pg', 'swarms');
+  SWARMS_DIR = path.join(TMP_ROOT, '.ppg', 'swarms');
   await fs.mkdir(SWARMS_DIR, { recursive: true });
 });
 

--- a/src/core/template.test.ts
+++ b/src/core/template.test.ts
@@ -5,7 +5,7 @@ const baseContext: TemplateContext = {
   WORKTREE_PATH: '/tmp/wt',
   BRANCH: 'ppg/feat',
   AGENT_ID: 'ag-test1234',
-  RESULT_FILE: '/tmp/.pg/results/ag-test1234.md',
+  RESULT_FILE: '/tmp/.ppg/results/ag-test1234.md',
   PROJECT_ROOT: '/tmp/project',
 };
 

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -21,56 +21,56 @@ const ROOT = '/tmp/project';
 
 describe('paths', () => {
   test('pgDir', () => {
-    expect(pgDir(ROOT)).toBe(path.join(ROOT, '.pg'));
+    expect(pgDir(ROOT)).toBe(path.join(ROOT, '.ppg'));
   });
 
   test('manifestPath', () => {
-    expect(manifestPath(ROOT)).toBe(path.join(ROOT, '.pg', 'manifest.json'));
+    expect(manifestPath(ROOT)).toBe(path.join(ROOT, '.ppg', 'manifest.json'));
   });
 
   test('configPath', () => {
-    expect(configPath(ROOT)).toBe(path.join(ROOT, '.pg', 'config.yaml'));
+    expect(configPath(ROOT)).toBe(path.join(ROOT, '.ppg', 'config.yaml'));
   });
 
   test('resultsDir', () => {
-    expect(resultsDir(ROOT)).toBe(path.join(ROOT, '.pg', 'results'));
+    expect(resultsDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'results'));
   });
 
   test('resultFile', () => {
     expect(resultFile(ROOT, 'ag-abc12345')).toBe(
-      path.join(ROOT, '.pg', 'results', 'ag-abc12345.md'),
+      path.join(ROOT, '.ppg', 'results', 'ag-abc12345.md'),
     );
   });
 
   test('templatesDir', () => {
-    expect(templatesDir(ROOT)).toBe(path.join(ROOT, '.pg', 'templates'));
+    expect(templatesDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'templates'));
   });
 
   test('logsDir', () => {
-    expect(logsDir(ROOT)).toBe(path.join(ROOT, '.pg', 'logs'));
+    expect(logsDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'logs'));
   });
 
   test('promptsDir', () => {
-    expect(promptsDir(ROOT)).toBe(path.join(ROOT, '.pg', 'prompts'));
+    expect(promptsDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'prompts'));
   });
 
   test('swarmsDir', () => {
-    expect(swarmsDir(ROOT)).toBe(path.join(ROOT, '.pg', 'swarms'));
+    expect(swarmsDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'swarms'));
   });
 
   test('promptFile', () => {
     expect(promptFile(ROOT, 'ag-abc12345')).toBe(
-      path.join(ROOT, '.pg', 'prompts', 'ag-abc12345.md'),
+      path.join(ROOT, '.ppg', 'prompts', 'ag-abc12345.md'),
     );
   });
 
   test('agentPromptsDir', () => {
-    expect(agentPromptsDir(ROOT)).toBe(path.join(ROOT, '.pg', 'agent-prompts'));
+    expect(agentPromptsDir(ROOT)).toBe(path.join(ROOT, '.ppg', 'agent-prompts'));
   });
 
   test('agentPromptFile', () => {
     expect(agentPromptFile(ROOT, 'ag-abc12345')).toBe(
-      path.join(ROOT, '.pg', 'agent-prompts', 'ag-abc12345.md'),
+      path.join(ROOT, '.ppg', 'agent-prompts', 'ag-abc12345.md'),
     );
   });
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-const PG_DIR = '.pg';
+const PG_DIR = '.ppg';
 
 export function pgDir(projectRoot: string): string {
   return path.join(projectRoot, PG_DIR);

--- a/src/test-fixtures.ts
+++ b/src/test-fixtures.ts
@@ -9,7 +9,7 @@ export function makeAgent(overrides?: Partial<AgentEntry>): AgentEntry {
     status: 'running',
     tmuxTarget: 'ppg:1.0',
     prompt: 'Do the thing',
-    resultFile: '/tmp/project/.pg/results/ag-test1234.md',
+    resultFile: '/tmp/project/.ppg/results/ag-test1234.md',
     startedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
   };

--- a/vision.md
+++ b/vision.md
@@ -34,7 +34,7 @@ ppg (Pure Point Guard) is a local orchestration system for parallel AI coding ag
 - **Requires tmux + git worktrees** — these are the foundational abstractions
 - **Node.js >= 20** — ESM-only, modern TypeScript
 - **Single-repo** — all worktrees are branches of the same repository
-- **Local filesystem** — manifest, config, prompts, results, and templates all live in `.pg/`
+- **Local filesystem** — manifest, config, prompts, results, and templates all live in `.ppg/`
 
 ## Architecture Decisions
 
@@ -43,7 +43,7 @@ ppg (Pure Point Guard) is a local orchestration system for parallel AI coding ag
 - **tmux process management** — One session per project, one window per worktree, one pane per agent. tmux provides attach, logs, kill, and status detection for free
 - **Manifest with file-level locking** — `proper-lockfile` (10s stale, 5 retries) + `write-file-atomic` for safe concurrent access from multiple ppg commands
 - **Template `{{VAR}}` system** — Simple, no dependencies, built-in variables for agent context (WORKTREE_PATH, BRANCH, AGENT_ID, RESULT_FILE, etc.)
-- **Agent-agnostic config** — Agents defined in `.pg/config.yaml` with `command`, `promptFlag`, `interactive` properties. Default: Claude Code
+- **Agent-agnostic config** — Agents defined in `.ppg/config.yaml` with `command`, `promptFlag`, `interactive` properties. Default: Claude Code
 - **Signal-stack status detection** — Layered priority: result file → pane existence → pane liveness → current command → running. No IPC required
 
 ## Success Criteria


### PR DESCRIPTION
## Summary
- Renamed the config directory constant from `.pg` to `.ppg` to match the tool name (`ppg`)
- Updated all source code references (paths.ts constant, init.ts gitignore entries and messages, cli.ts help text, list.ts/swarm.ts/pr.ts user-facing strings)
- Updated all test files (paths.test.ts, pr.test.ts, swarm.test.ts, template.test.ts, test-fixtures.ts)
- Updated all documentation (CLAUDE.md, README.md, vision.md, skills/ppg-conductor references)

## Test plan
- [x] All 176 tests pass (`npm test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] No remaining `.pg/` references in source or docs (verified via grep)
- [ ] Existing `.pg/` directories on disk are unaffected — users get `.ppg/` on next `ppg init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation references to reflect the new internal directory structure and naming convention.

* **Chores**
  * Renamed internal configuration and state directory from `.pg` to `.ppg` throughout the codebase, affecting configuration files, templates, results, logs, and other stored data locations. Updated corresponding help text, error messages, and test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->