### PR TITLE
feat: calendar UI for Schedules + cron add/remove CLI

### DIFF
--- a/PPG CLI/PPG CLI/CronParser.swift
+++ b/PPG CLI/PPG CLI/CronParser.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+// MARK: - CronParser
+
+/// Evaluates 5-field cron expressions and computes occurrences within a date range.
+/// Fields: minute (0-59), hour (0-23), day-of-month (1-31), month (1-12), day-of-week (0-6, 0=Sunday).
+/// Supports: * (any), N (exact), N-M (range), N,M,O (list), */N (step), N-M/S (range with step).
+struct CronParser {
+
+    struct CronExpression {
+        let minutes: Set<Int>
+        let hours: Set<Int>
+        let daysOfMonth: Set<Int>
+        let months: Set<Int>
+        let daysOfWeek: Set<Int>
+        let raw: String
+    }
+
+    enum ParseError: Error {
+        case invalidFieldCount(String)
+        case invalidField(String, String)
+    }
+
+    // MARK: - Parsing
+
+    static func parse(_ expression: String) throws -> CronExpression {
+        let parts = expression.trimmingCharacters(in: .whitespaces).split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard parts.count == 5 else {
+            throw ParseError.invalidFieldCount(expression)
+        }
+
+        let minutes = try parseField(parts[0], min: 0, max: 59, name: "minute")
+        let hours = try parseField(parts[1], min: 0, max: 23, name: "hour")
+        let daysOfMonth = try parseField(parts[2], min: 1, max: 31, name: "day-of-month")
+        let months = try parseField(parts[3], min: 1, max: 12, name: "month")
+        let daysOfWeek = try parseField(parts[4], min: 0, max: 6, name: "day-of-week")
+
+        return CronExpression(
+            minutes: minutes,
+            hours: hours,
+            daysOfMonth: daysOfMonth,
+            months: months,
+            daysOfWeek: daysOfWeek,
+            raw: expression
+        )
+    }
+
+    private static func parseField(_ field: String, min: Int, max: Int, name: String) throws -> Set<Int> {
+        var result = Set<Int>()
+
+        // Handle comma-separated list
+        let parts = field.split(separator: ",").map(String.init)
+        for part in parts {
+            let values = try parsePart(part.trimmingCharacters(in: .whitespaces), min: min, max: max, name: name)
+            result.formUnion(values)
+        }
+
+        return result
+    }
+
+    private static func parsePart(_ part: String, min: Int, max: Int, name: String) throws -> Set<Int> {
+        // Check for step: */N or N-M/S
+        let stepComponents = part.split(separator: "/", maxSplits: 1).map(String.init)
+
+        if stepComponents.count == 2 {
+            guard let step = Int(stepComponents[1]), step > 0 else {
+                throw ParseError.invalidField(name, part)
+            }
+            let range: (Int, Int)
+            if stepComponents[0] == "*" {
+                range = (min, max)
+            } else if stepComponents[0].contains("-") {
+                range = try parseRange(stepComponents[0], min: min, max: max, name: name)
+            } else {
+                // N/S — start at N, step by S
+                guard let start = Int(stepComponents[0]), start >= min, start <= max else {
+                    throw ParseError.invalidField(name, part)
+                }
+                range = (start, max)
+            }
+            var result = Set<Int>()
+            var current = range.0
+            while current <= range.1 {
+                result.insert(current)
+                current += step
+            }
+            return result
+        }
+
+        // Wildcard
+        if part == "*" {
+            return Set(min...max)
+        }
+
+        // Range: N-M
+        if part.contains("-") {
+            let r = try parseRange(part, min: min, max: max, name: name)
+            return Set(r.0...r.1)
+        }
+
+        // Exact value
+        guard let value = Int(part), value >= min, value <= max else {
+            throw ParseError.invalidField(name, part)
+        }
+        return Set([value])
+    }
+
+    private static func parseRange(_ part: String, min: Int, max: Int, name: String) throws -> (Int, Int) {
+        let rangeParts = part.split(separator: "-", maxSplits: 1).map(String.init)
+        guard rangeParts.count == 2,
+              let start = Int(rangeParts[0]),
+              let end = Int(rangeParts[1]),
+              start >= min, end <= max, start <= end else {
+            throw ParseError.invalidField(name, part)
+        }
+        return (start, end)
+    }
+
+    // MARK: - Occurrence Computation
+
+    /// Compute all cron occurrences within the given date range.
+    /// Returns at most `limit` results.
+    static func occurrences(
+        of expression: CronExpression,
+        from startDate: Date,
+        to endDate: Date,
+        calendar: Calendar = .current,
+        limit: Int = 1000
+    ) -> [Date] {
+        guard startDate < endDate else { return [] }
+
+        var results: [Date] = []
+
+        // Start from the beginning of the minute of startDate
+        var comps = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: startDate)
+        comps.second = 0
+
+        guard var current = calendar.date(from: comps) else { return [] }
+
+        while current <= endDate && results.count < limit {
+            let c = calendar.dateComponents([.minute, .hour, .day, .month, .weekday], from: current)
+
+            guard let minute = c.minute, let hour = c.hour,
+                  let day = c.day, let month = c.month,
+                  let weekday = c.weekday else {
+                // Advance by 1 minute
+                current = calendar.date(byAdding: .minute, value: 1, to: current) ?? endDate
+                continue
+            }
+
+            // Calendar weekday is 1=Sunday..7=Saturday, cron is 0=Sunday..6=Saturday
+            let cronWeekday = weekday - 1
+
+            if expression.months.contains(month) &&
+               expression.daysOfMonth.contains(day) &&
+               expression.daysOfWeek.contains(cronWeekday) &&
+               expression.hours.contains(hour) &&
+               expression.minutes.contains(minute) {
+                if current >= startDate {
+                    results.append(current)
+                }
+            }
+
+            // Smart advancement: if month doesn't match, skip to next month
+            if !expression.months.contains(month) {
+                if let nextMonth = calendar.date(byAdding: .month, value: 1, to: calendar.startOfDay(for: current)) {
+                    var nc = calendar.dateComponents([.year, .month], from: nextMonth)
+                    nc.day = 1; nc.hour = 0; nc.minute = 0; nc.second = 0
+                    current = calendar.date(from: nc) ?? endDate
+                    continue
+                }
+            }
+
+            // If day doesn't match both day-of-month and day-of-week, skip to next day
+            if !expression.daysOfMonth.contains(day) || !expression.daysOfWeek.contains(cronWeekday) {
+                if let nextDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: current)) {
+                    current = nextDay
+                    continue
+                }
+            }
+
+            // If hour doesn't match, skip to next hour
+            if !expression.hours.contains(hour) {
+                if let nextHour = calendar.date(byAdding: .hour, value: 1, to: current) {
+                    var nc = calendar.dateComponents([.year, .month, .day, .hour], from: nextHour)
+                    nc.minute = 0; nc.second = 0
+                    current = calendar.date(from: nc) ?? endDate
+                    continue
+                }
+            }
+
+            // Advance by 1 minute
+            current = calendar.date(byAdding: .minute, value: 1, to: current) ?? endDate
+        }
+
+        return results
+    }
+
+    /// Check if a cron expression fires more than the given threshold per day.
+    static func isHighFrequency(_ expression: CronExpression, threshold: Int = 48) -> Bool {
+        // Count: matching minutes × matching hours (for a full day where month/dom/dow all match)
+        let matchingMinutes = expression.minutes.count
+        let matchingHours = expression.hours.count
+        return matchingMinutes * matchingHours > threshold
+    }
+
+    // MARK: - Next Run
+
+    /// Compute the next occurrence after `date`.
+    static func nextOccurrence(
+        of expression: CronExpression,
+        after date: Date,
+        calendar: Calendar = .current
+    ) -> Date? {
+        let nextMinute = calendar.date(byAdding: .minute, value: 1, to: date) ?? date
+        let farFuture = calendar.date(byAdding: .year, value: 1, to: date) ?? date
+        let results = occurrences(of: expression, from: nextMinute, to: farFuture, calendar: calendar, limit: 1)
+        return results.first
+    }
+
+    // MARK: - Human-Readable Description
+
+    static func humanReadable(_ expression: String) -> String {
+        let parts = expression.trimmingCharacters(in: .whitespaces).split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard parts.count == 5 else { return expression }
+
+        let (min, hour, dom, mon, dow) = (parts[0], parts[1], parts[2], parts[3], parts[4])
+
+        // Daily at specific time
+        if min != "*" && hour != "*" && dom == "*" && mon == "*" && dow == "*" {
+            if let m = Int(min), let h = Int(hour) {
+                return "Every day at \(String(format: "%d:%02d", h, m))"
+            }
+        }
+
+        // Every N minutes
+        if min.hasPrefix("*/"), hour == "*" && dom == "*" && mon == "*" && dow == "*" {
+            let interval = String(min.dropFirst(2))
+            return "Every \(interval) minutes"
+        }
+
+        // Hourly at :MM
+        if min != "*" && hour == "*" && dom == "*" && mon == "*" && dow == "*" {
+            if let m = Int(min) {
+                return "Every hour at :\(String(format: "%02d", m))"
+            }
+        }
+
+        // Weekly on specific day
+        if dow != "*" && dom == "*" && mon == "*" {
+            let days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+            if let d = Int(dow), d >= 0, d < 7 {
+                if let m = Int(min), let h = Int(hour) {
+                    return "\(days[d]) at \(String(format: "%d:%02d", h, m))"
+                }
+                return "Every \(days[d])"
+            }
+        }
+
+        // Monthly on specific day
+        if dom != "*" && mon == "*" && dow == "*" {
+            if let d = Int(dom), let m = Int(min), let h = Int(hour) {
+                let suffix: String
+                switch d {
+                case 1, 21, 31: suffix = "st"
+                case 2, 22: suffix = "nd"
+                case 3, 23: suffix = "rd"
+                default: suffix = "th"
+                }
+                return "Monthly on the \(d)\(suffix) at \(String(format: "%d:%02d", h, m))"
+            }
+        }
+
+        return expression
+    }
+}

--- a/PPG CLI/PPG CLI/SchedulesView.swift
+++ b/PPG CLI/PPG CLI/SchedulesView.swift
@@ -13,28 +13,63 @@ struct ScheduleInfo {
     let vars: [(String, String)]
 }
 
-// MARK: - SchedulesView
+/// A computed calendar event from a schedule + cron occurrence.
+struct CalendarEvent {
+    let schedule: ScheduleInfo
+    let date: Date
+    let color: NSColor
+    let isHighFrequency: Bool
+}
 
-class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextStorageDelegate {
+// MARK: - Calendar View Mode
 
-    private let splitView = NSSplitView()
-    private let listScrollView = NSScrollView()
-    private let tableView = NSTableView()
-    private let editorScrollView = NSScrollView()
-    private let editorTextView = NSTextView()
-    private let headerLabel = NSTextField(labelWithString: "Schedules (0)")
-    private let newButton = NSButton()
-    private let daemonButton = NSButton()
+enum CalendarViewMode: Int {
+    case day = 0
+    case week = 1
+    case month = 2
+}
+
+// MARK: - Project Color Palette
+
+private let projectColors: [NSColor] = [
+    .systemBlue, .systemPurple, .systemTeal, .systemOrange,
+    .systemPink, .systemIndigo, .systemGreen, .systemBrown,
+    .systemCyan, .systemMint
+]
+
+private func colorForProject(_ name: String) -> NSColor {
+    let hash = abs(name.hashValue)
+    return projectColors[hash % projectColors.count]
+}
+
+// MARK: - SchedulesView (Calendar)
+
+class SchedulesView: NSView {
+
+    // MARK: - Header Controls
+    private let headerBar = NSView()
+    private let headerLabel = NSTextField(labelWithString: "Schedules")
     private let daemonDot = NSView()
-    private let saveButton = NSButton()
-    private let deleteButton = NSButton()
+    private let daemonButton = NSButton()
+    private let prevButton = NSButton()
+    private let todayButton = NSButton()
+    private let nextButton = NSButton()
+    private let dateLabel = NSTextField(labelWithString: "")
+    private let viewSegment = NSSegmentedControl(labels: ["Day", "Week", "Month"], trackingMode: .selectOne, target: nil, action: nil)
+    private let newButton = NSButton()
     private let emptyLabel = NSTextField(labelWithString: "No schedules found")
 
+    // MARK: - Content Area
+    private let contentContainer = NSView()
+    private var monthView: CalendarMonthView?
+    private var weekView: CalendarWeekView?
+    private var dayView: CalendarDayView?
+
+    // MARK: - State
     private var schedules: [ScheduleInfo] = []
-    private var selectedIndex: Int? = nil
-    private var isDirty = false
-    /// Tracks which schedules.yaml file is loaded in the editor.
-    private var loadedFilePath: String? = nil
+    private var events: [CalendarEvent] = []
+    private var currentDate = Date()
+    private var viewMode: CalendarViewMode = .month
     private var daemonRunning = false
     private var projects: [ProjectContext] = []
 
@@ -53,25 +88,16 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
     func configure(projects: [ProjectContext]) {
         self.projects = projects
         schedules = Self.scanSchedules(projects: projects)
-        headerLabel.stringValue = "Schedules (\(schedules.count))"
-        tableView.reloadData()
         emptyLabel.isHidden = !schedules.isEmpty
-        if let idx = selectedIndex, idx < schedules.count {
-            tableView.selectRowIndexes(IndexSet(integer: idx), byExtendingSelection: false)
-        } else {
-            selectedIndex = nil
-            editorTextView.string = ""
-            loadedFilePath = nil
-            saveButton.isEnabled = false
-            deleteButton.isEnabled = false
-        }
+        recomputeEvents()
+        updateDateLabel()
+        refreshCurrentView()
         checkDaemonStatus()
     }
 
-    // MARK: - File Scanning
+    // MARK: - File Scanning (unchanged from original)
 
     static func scanSchedules(projects: [ProjectContext]) -> [ScheduleInfo] {
-        let fm = FileManager.default
         var results: [ScheduleInfo] = []
 
         for ctx in projects {
@@ -100,7 +126,7 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
     private struct ParsedSchedule {
         var name: String
         var cron: String
-        var type: String    // "swarm" or "prompt"
+        var type: String
         var target: String
         var vars: [(String, String)]
     }
@@ -117,30 +143,22 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
 
-            // Top-level key
             if !line.hasPrefix(" ") && !line.hasPrefix("\t") && !line.hasPrefix("-") {
                 if let c = current {
                     results.append(c)
                     current = nil
                 }
                 inVars = false
-                if trimmed.hasPrefix("schedules:") {
-                    inSchedules = true
-                } else {
-                    inSchedules = false
-                }
+                inSchedules = trimmed.hasPrefix("schedules:")
                 continue
             }
 
             guard inSchedules else { continue }
 
             if trimmed.hasPrefix("- ") || trimmed == "-" {
-                if let c = current {
-                    results.append(c)
-                }
+                if let c = current { results.append(c) }
                 current = ParsedSchedule(name: "", cron: "", type: "", target: "", vars: [])
                 inVars = false
-                // Handle inline key on the dash line: "- name: foo"
                 let afterDash = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
                 if !afterDash.isEmpty {
                     applyKeyValue(afterDash, to: &current!, inVars: &inVars)
@@ -149,30 +167,17 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
                 applyKeyValue(trimmed, to: &current!, inVars: &inVars)
             }
         }
-        if let c = current {
-            results.append(c)
-        }
+        if let c = current { results.append(c) }
         return results
     }
 
     private static func applyKeyValue(_ trimmed: String, to entry: inout ParsedSchedule, inVars: inout Bool) {
-        if trimmed.hasPrefix("name:") {
-            entry.name = yamlValue(trimmed)
-            inVars = false
-        } else if trimmed.hasPrefix("cron:") {
-            entry.cron = yamlValue(trimmed)
-            inVars = false
-        } else if trimmed.hasPrefix("swarm:") {
-            entry.type = "swarm"
-            entry.target = yamlValue(trimmed)
-            inVars = false
-        } else if trimmed.hasPrefix("prompt:") {
-            entry.type = "prompt"
-            entry.target = yamlValue(trimmed)
-            inVars = false
-        } else if trimmed.hasPrefix("vars:") {
-            inVars = true
-        } else if inVars && trimmed.contains(":") {
+        if trimmed.hasPrefix("name:") { entry.name = yamlValue(trimmed); inVars = false }
+        else if trimmed.hasPrefix("cron:") { entry.cron = yamlValue(trimmed); inVars = false }
+        else if trimmed.hasPrefix("swarm:") { entry.type = "swarm"; entry.target = yamlValue(trimmed); inVars = false }
+        else if trimmed.hasPrefix("prompt:") { entry.type = "prompt"; entry.target = yamlValue(trimmed); inVars = false }
+        else if trimmed.hasPrefix("vars:") { inVars = true }
+        else if inVars && trimmed.contains(":") {
             let parts = trimmed.split(separator: ":", maxSplits: 1)
             if parts.count == 2 {
                 let k = parts[0].trimmingCharacters(in: .whitespaces)
@@ -182,11 +187,9 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
         }
     }
 
-    private static func yamlValue(_ line: String) -> String {
+    static func yamlValue(_ line: String) -> String {
         guard let colonIdx = line.range(of: ":") else { return "" }
-        var value = String(line[colonIdx.upperBound...]).trimmingCharacters(in: .whitespaces)
-        value = stripQuotes(value)
-        return value
+        return stripQuotes(String(line[colonIdx.upperBound...]).trimmingCharacters(in: .whitespaces))
     }
 
     private static func stripQuotes(_ s: String) -> String {
@@ -195,6 +198,556 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
             value = String(value.dropFirst().dropLast())
         }
         return value
+    }
+
+    // MARK: - Event Computation
+
+    private func recomputeEvents() {
+        let cal = Calendar.current
+        let (start, end) = dateRangeForCurrentView(calendar: cal)
+        var allEvents: [CalendarEvent] = []
+
+        for schedule in schedules {
+            guard let expr = try? CronParser.parse(schedule.cronExpression) else { continue }
+            let color = colorForProject(schedule.projectName)
+            let highFreq = CronParser.isHighFrequency(expr)
+
+            if highFreq {
+                // For high-frequency crons, generate one event per day
+                var day = start
+                while day < end {
+                    allEvents.append(CalendarEvent(schedule: schedule, date: day, color: color, isHighFrequency: true))
+                    day = cal.date(byAdding: .day, value: 1, to: day) ?? end
+                }
+            } else {
+                let occurrences = CronParser.occurrences(of: expr, from: start, to: end, calendar: cal, limit: 2000)
+                for date in occurrences {
+                    allEvents.append(CalendarEvent(schedule: schedule, date: date, color: color, isHighFrequency: false))
+                }
+            }
+        }
+
+        events = allEvents
+    }
+
+    private func dateRangeForCurrentView(calendar cal: Calendar) -> (Date, Date) {
+        switch viewMode {
+        case .month:
+            // First day of month's week to last day of month's last week
+            let comps = cal.dateComponents([.year, .month], from: currentDate)
+            let firstOfMonth = cal.date(from: comps)!
+            let firstWeekday = cal.component(.weekday, from: firstOfMonth) // 1=Sun
+            let startOffset = -(firstWeekday - cal.firstWeekday + 7) % 7
+            let start = cal.date(byAdding: .day, value: startOffset, to: firstOfMonth)!
+            let end = cal.date(byAdding: .day, value: 42, to: start)! // 6 weeks
+            return (start, end)
+        case .week:
+            let weekday = cal.component(.weekday, from: currentDate)
+            let startOffset = -(weekday - cal.firstWeekday + 7) % 7
+            let start = cal.startOfDay(for: cal.date(byAdding: .day, value: startOffset, to: currentDate)!)
+            let end = cal.date(byAdding: .day, value: 7, to: start)!
+            return (start, end)
+        case .day:
+            let start = cal.startOfDay(for: currentDate)
+            let end = cal.date(byAdding: .day, value: 1, to: start)!
+            return (start, end)
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupViews() {
+        wantsLayer = true
+        layer?.backgroundColor = Theme.contentBackground.resolvedCGColor(for: effectiveAppearance)
+
+        // Header bar
+        headerBar.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(headerBar)
+
+        // Title
+        headerLabel.font = .boldSystemFont(ofSize: 14)
+        headerLabel.textColor = Theme.primaryText
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(headerLabel)
+
+        // Daemon dot
+        daemonDot.translatesAutoresizingMaskIntoConstraints = false
+        daemonDot.wantsLayer = true
+        daemonDot.layer?.cornerRadius = 5
+        daemonDot.layer?.backgroundColor = NSColor.systemRed.cgColor
+        headerBar.addSubview(daemonDot)
+
+        // Daemon button
+        daemonButton.bezelStyle = .accessoryBarAction
+        daemonButton.title = "Start Daemon"
+        daemonButton.font = .systemFont(ofSize: 11)
+        daemonButton.isBordered = false
+        daemonButton.contentTintColor = Theme.primaryText
+        daemonButton.target = self
+        daemonButton.action = #selector(daemonToggleClicked)
+        daemonButton.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(daemonButton)
+
+        // Navigation: < Today >
+        prevButton.bezelStyle = .accessoryBarAction
+        prevButton.image = NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")
+        prevButton.isBordered = false
+        prevButton.contentTintColor = Theme.primaryText
+        prevButton.target = self
+        prevButton.action = #selector(prevClicked)
+        prevButton.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(prevButton)
+
+        todayButton.bezelStyle = .accessoryBarAction
+        todayButton.title = "Today"
+        todayButton.font = .systemFont(ofSize: 11)
+        todayButton.isBordered = false
+        todayButton.contentTintColor = Theme.primaryText
+        todayButton.target = self
+        todayButton.action = #selector(todayClicked)
+        todayButton.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(todayButton)
+
+        nextButton.bezelStyle = .accessoryBarAction
+        nextButton.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Next")
+        nextButton.isBordered = false
+        nextButton.contentTintColor = Theme.primaryText
+        nextButton.target = self
+        nextButton.action = #selector(nextClicked)
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(nextButton)
+
+        // Date label
+        dateLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        dateLabel.textColor = Theme.primaryText
+        dateLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(dateLabel)
+
+        // View segment
+        viewSegment.selectedSegment = 2 // Month default
+        viewSegment.target = self
+        viewSegment.action = #selector(viewModeChanged)
+        viewSegment.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(viewSegment)
+
+        // New schedule button
+        newButton.bezelStyle = .accessoryBarAction
+        newButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New Schedule")
+        newButton.title = " New Schedule"
+        newButton.imagePosition = .imageLeading
+        newButton.font = .systemFont(ofSize: 11)
+        newButton.isBordered = false
+        newButton.contentTintColor = Theme.primaryText
+        newButton.target = self
+        newButton.action = #selector(newScheduleClicked)
+        newButton.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(newButton)
+
+        // Header separator
+        let headerSep = NSBox()
+        headerSep.boxType = .separator
+        headerSep.translatesAutoresizingMaskIntoConstraints = false
+        headerBar.addSubview(headerSep)
+
+        // Content container
+        contentContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentContainer)
+
+        // Empty label
+        emptyLabel.font = .systemFont(ofSize: 14)
+        emptyLabel.textColor = .tertiaryLabelColor
+        emptyLabel.alignment = .center
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.isHidden = true
+        addSubview(emptyLabel)
+
+        NSLayoutConstraint.activate([
+            headerBar.topAnchor.constraint(equalTo: topAnchor),
+            headerBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerBar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            headerBar.heightAnchor.constraint(equalToConstant: 40),
+
+            headerLabel.leadingAnchor.constraint(equalTo: headerBar.leadingAnchor, constant: 12),
+            headerLabel.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            daemonDot.leadingAnchor.constraint(equalTo: headerLabel.trailingAnchor, constant: 8),
+            daemonDot.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+            daemonDot.widthAnchor.constraint(equalToConstant: 10),
+            daemonDot.heightAnchor.constraint(equalToConstant: 10),
+
+            daemonButton.leadingAnchor.constraint(equalTo: daemonDot.trailingAnchor, constant: 4),
+            daemonButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            prevButton.leadingAnchor.constraint(equalTo: daemonButton.trailingAnchor, constant: 16),
+            prevButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            todayButton.leadingAnchor.constraint(equalTo: prevButton.trailingAnchor, constant: 2),
+            todayButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            nextButton.leadingAnchor.constraint(equalTo: todayButton.trailingAnchor, constant: 2),
+            nextButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            dateLabel.leadingAnchor.constraint(equalTo: nextButton.trailingAnchor, constant: 12),
+            dateLabel.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            newButton.trailingAnchor.constraint(equalTo: headerBar.trailingAnchor, constant: -8),
+            newButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            viewSegment.trailingAnchor.constraint(equalTo: newButton.leadingAnchor, constant: -12),
+            viewSegment.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
+
+            headerSep.bottomAnchor.constraint(equalTo: headerBar.bottomAnchor),
+            headerSep.leadingAnchor.constraint(equalTo: headerBar.leadingAnchor),
+            headerSep.trailingAnchor.constraint(equalTo: headerBar.trailingAnchor),
+
+            contentContainer.topAnchor.constraint(equalTo: headerBar.bottomAnchor),
+            contentContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            emptyLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        updateDateLabel()
+        showMonthView()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        layer?.backgroundColor = Theme.contentBackground.resolvedCGColor(for: effectiveAppearance)
+    }
+
+    // MARK: - Date Label
+
+    private func updateDateLabel() {
+        let fmt = DateFormatter()
+        let cal = Calendar.current
+
+        switch viewMode {
+        case .month:
+            fmt.dateFormat = "MMMM yyyy"
+            dateLabel.stringValue = fmt.string(from: currentDate)
+        case .week:
+            let weekday = cal.component(.weekday, from: currentDate)
+            let startOffset = -(weekday - cal.firstWeekday + 7) % 7
+            let weekStart = cal.date(byAdding: .day, value: startOffset, to: currentDate)!
+            let weekEnd = cal.date(byAdding: .day, value: 6, to: weekStart)!
+            fmt.dateFormat = "MMM d"
+            let startStr = fmt.string(from: weekStart)
+            let endStr = fmt.string(from: weekEnd)
+            fmt.dateFormat = ", yyyy"
+            let yearStr = fmt.string(from: weekEnd)
+            dateLabel.stringValue = "\(startStr) - \(endStr)\(yearStr)"
+        case .day:
+            fmt.dateFormat = "EEEE, MMMM d, yyyy"
+            dateLabel.stringValue = fmt.string(from: currentDate)
+        }
+    }
+
+    // MARK: - View Switching
+
+    private func refreshCurrentView() {
+        switch viewMode {
+        case .month: showMonthView()
+        case .week: showWeekView()
+        case .day: showDayView()
+        }
+    }
+
+    private func clearContent() {
+        monthView?.removeFromSuperview()
+        weekView?.removeFromSuperview()
+        dayView?.removeFromSuperview()
+    }
+
+    private func showMonthView() {
+        clearContent()
+        let mv = CalendarMonthView()
+        mv.translatesAutoresizingMaskIntoConstraints = false
+        mv.onDayClicked = { [weak self] date in
+            self?.currentDate = date
+            self?.viewMode = .day
+            self?.viewSegment.selectedSegment = CalendarViewMode.day.rawValue
+            self?.recomputeEvents()
+            self?.updateDateLabel()
+            self?.refreshCurrentView()
+        }
+        mv.onEventClicked = { [weak self] event, sourceView in
+            self?.showEventPopover(for: event, relativeTo: sourceView)
+        }
+        contentContainer.addSubview(mv)
+        NSLayoutConstraint.activate([
+            mv.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            mv.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            mv.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            mv.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
+        ])
+        monthView = mv
+        mv.configure(currentDate: currentDate, events: events)
+    }
+
+    private func showWeekView() {
+        clearContent()
+        let wv = CalendarWeekView()
+        wv.translatesAutoresizingMaskIntoConstraints = false
+        wv.onEventClicked = { [weak self] event, sourceView in
+            self?.showEventPopover(for: event, relativeTo: sourceView)
+        }
+        wv.onEmptySlotClicked = { [weak self] date in
+            self?.showNewScheduleDialog(prefilledDate: date)
+        }
+        contentContainer.addSubview(wv)
+        NSLayoutConstraint.activate([
+            wv.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            wv.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            wv.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            wv.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
+        ])
+        weekView = wv
+        wv.configure(currentDate: currentDate, events: events)
+    }
+
+    private func showDayView() {
+        clearContent()
+        let dv = CalendarDayView()
+        dv.translatesAutoresizingMaskIntoConstraints = false
+        dv.onEventClicked = { [weak self] event, sourceView in
+            self?.showEventPopover(for: event, relativeTo: sourceView)
+        }
+        dv.onEmptySlotClicked = { [weak self] date in
+            self?.showNewScheduleDialog(prefilledDate: date)
+        }
+        contentContainer.addSubview(dv)
+        NSLayoutConstraint.activate([
+            dv.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            dv.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            dv.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            dv.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
+        ])
+        dayView = dv
+        dv.configure(currentDate: currentDate, events: events)
+    }
+
+    // MARK: - Event Detail Popover
+
+    private func showEventPopover(for event: CalendarEvent, relativeTo sourceView: NSView) {
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentSize = NSSize(width: 280, height: 0) // auto-height
+
+        let vc = NSViewController()
+        let container = NSView()
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.edgeInsets = NSEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+
+        // Name
+        let nameLabel = NSTextField(labelWithString: event.schedule.name)
+        nameLabel.font = .boldSystemFont(ofSize: 14)
+        nameLabel.textColor = Theme.primaryText
+        stack.addArrangedSubview(nameLabel)
+
+        // Cron expression
+        let cronRaw = event.schedule.cronExpression
+        let cronHuman = CronParser.humanReadable(cronRaw)
+        let cronLabel = NSTextField(labelWithString: "\(cronHuman)  (\(cronRaw))")
+        cronLabel.font = .systemFont(ofSize: 11)
+        cronLabel.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(cronLabel)
+
+        // Separator
+        let sep = NSBox()
+        sep.boxType = .separator
+        sep.translatesAutoresizingMaskIntoConstraints = false
+        stack.addArrangedSubview(sep)
+        sep.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -24).isActive = true
+
+        // Type
+        let typeIcon = event.schedule.type == "swarm" ? "arrow.triangle.branch" : "doc.text"
+        let typeStr = event.schedule.type == "swarm" ? "Swarm" : "Prompt"
+        let typeLabel = makeDetailRow(icon: typeIcon, text: "Type: \(typeStr)")
+        stack.addArrangedSubview(typeLabel)
+
+        // Target
+        let targetLabel = makeDetailRow(icon: "target", text: "Target: \(event.schedule.target)")
+        stack.addArrangedSubview(targetLabel)
+
+        // Project
+        let projectLabel = makeDetailRow(icon: "folder", text: "Project: \(event.schedule.projectName)")
+        stack.addArrangedSubview(projectLabel)
+
+        // Vars
+        if !event.schedule.vars.isEmpty {
+            let varsStr = event.schedule.vars.map { "\($0.0)=\($0.1)" }.joined(separator: ", ")
+            let varsLabel = makeDetailRow(icon: "list.bullet", text: "Vars: \(varsStr)")
+            stack.addArrangedSubview(varsLabel)
+        }
+
+        // High frequency indicator
+        if event.isHighFrequency {
+            let hfLabel = NSTextField(labelWithString: "High-frequency schedule (>48 runs/day)")
+            hfLabel.font = .systemFont(ofSize: 10, weight: .medium)
+            hfLabel.textColor = .systemOrange
+            stack.addArrangedSubview(hfLabel)
+        }
+
+        // Buttons
+        let buttonStack = NSStackView()
+        buttonStack.orientation = .horizontal
+        buttonStack.spacing = 8
+
+        let editButton = NSButton(title: "Edit", target: self, action: #selector(editScheduleFromPopover(_:)))
+        editButton.bezelStyle = .rounded
+        editButton.font = .systemFont(ofSize: 11)
+        editButton.tag = schedules.firstIndex(where: { $0.name == event.schedule.name && $0.filePath == event.schedule.filePath }) ?? -1
+
+        let deleteButton = NSButton(title: "Delete", target: self, action: #selector(deleteScheduleFromPopover(_:)))
+        deleteButton.bezelStyle = .rounded
+        deleteButton.font = .systemFont(ofSize: 11)
+        deleteButton.contentTintColor = .systemRed
+        deleteButton.tag = editButton.tag
+
+        buttonStack.addArrangedSubview(editButton)
+        buttonStack.addArrangedSubview(deleteButton)
+        stack.addArrangedSubview(buttonStack)
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        vc.view = container
+        popover.contentViewController = vc
+        popover.show(relativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY)
+    }
+
+    private func makeDetailRow(icon: String, text: String) -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 4
+        let img = NSImageView()
+        img.image = NSImage(systemSymbolName: icon, accessibilityDescription: nil)
+        img.translatesAutoresizingMaskIntoConstraints = false
+        img.widthAnchor.constraint(equalToConstant: 14).isActive = true
+        img.heightAnchor.constraint(equalToConstant: 14).isActive = true
+        img.contentTintColor = .secondaryLabelColor
+        let label = NSTextField(labelWithString: text)
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = Theme.primaryText
+        label.lineBreakMode = .byTruncatingTail
+        row.addArrangedSubview(img)
+        row.addArrangedSubview(label)
+        return row
+    }
+
+    // MARK: - Actions
+
+    @objc private func prevClicked() {
+        let cal = Calendar.current
+        switch viewMode {
+        case .month: currentDate = cal.date(byAdding: .month, value: -1, to: currentDate)!
+        case .week: currentDate = cal.date(byAdding: .weekOfYear, value: -1, to: currentDate)!
+        case .day: currentDate = cal.date(byAdding: .day, value: -1, to: currentDate)!
+        }
+        recomputeEvents()
+        updateDateLabel()
+        refreshCurrentView()
+    }
+
+    @objc private func nextClicked() {
+        let cal = Calendar.current
+        switch viewMode {
+        case .month: currentDate = cal.date(byAdding: .month, value: 1, to: currentDate)!
+        case .week: currentDate = cal.date(byAdding: .weekOfYear, value: 1, to: currentDate)!
+        case .day: currentDate = cal.date(byAdding: .day, value: 1, to: currentDate)!
+        }
+        recomputeEvents()
+        updateDateLabel()
+        refreshCurrentView()
+    }
+
+    @objc private func todayClicked() {
+        currentDate = Date()
+        recomputeEvents()
+        updateDateLabel()
+        refreshCurrentView()
+    }
+
+    @objc private func viewModeChanged() {
+        viewMode = CalendarViewMode(rawValue: viewSegment.selectedSegment) ?? .month
+        recomputeEvents()
+        updateDateLabel()
+        refreshCurrentView()
+    }
+
+    @objc private func editScheduleFromPopover(_ sender: NSButton) {
+        let idx = sender.tag
+        guard idx >= 0, idx < schedules.count else { return }
+        // Close any open popover
+        if let popover = (sender.window?.contentView?.subviews.first as? NSPopover) {
+            popover.close()
+        }
+        showEditScheduleDialog(at: idx)
+    }
+
+    @objc private func deleteScheduleFromPopover(_ sender: NSButton) {
+        let idx = sender.tag
+        guard idx >= 0, idx < schedules.count else { return }
+        let schedule = schedules[idx]
+
+        let alert = NSAlert()
+        alert.messageText = "Delete schedule \"\(schedule.name)\"?"
+        alert.informativeText = "This will remove the schedule entry from schedules.yaml."
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        guard let content = try? String(contentsOfFile: schedule.filePath, encoding: .utf8) else { return }
+        let filtered = removeScheduleEntry(named: schedule.name, from: content)
+
+        do {
+            if filtered.trimmingCharacters(in: .whitespacesAndNewlines) == "schedules:" ||
+               filtered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                try FileManager.default.removeItem(atPath: schedule.filePath)
+            } else {
+                try filtered.write(toFile: schedule.filePath, atomically: true, encoding: .utf8)
+            }
+            configure(projects: projects)
+        } catch {
+            let errAlert = NSAlert()
+            errAlert.messageText = "Failed to Delete"
+            errAlert.informativeText = error.localizedDescription
+            errAlert.alertStyle = .warning
+            errAlert.runModal()
+        }
+    }
+
+    @objc private func daemonToggleClicked() {
+        guard let ctx = projects.first else { return }
+        let command = daemonRunning ? "cron stop" : "cron start"
+        let projectRoot = ctx.projectRoot
+        daemonButton.isEnabled = false
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            _ = PPGService.shared.runPPGCommand(command, projectRoot: projectRoot)
+            DispatchQueue.main.async {
+                self?.daemonButton.isEnabled = true
+                self?.checkDaemonStatus()
+            }
+        }
+    }
+
+    @objc private func newScheduleClicked() {
+        showNewScheduleDialog(prefilledDate: nil)
     }
 
     // MARK: - Daemon Status
@@ -227,453 +780,9 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
         }
     }
 
-    // MARK: - Setup
+    // MARK: - Schedule CRUD
 
-    private func setupViews() {
-        wantsLayer = true
-        layer?.backgroundColor = Theme.contentBackground.resolvedCGColor(for: effectiveAppearance)
-
-        // Header
-        let headerBar = NSView()
-        headerBar.translatesAutoresizingMaskIntoConstraints = false
-
-        headerLabel.font = .boldSystemFont(ofSize: 14)
-        headerLabel.textColor = Theme.primaryText
-        headerLabel.translatesAutoresizingMaskIntoConstraints = false
-        headerBar.addSubview(headerLabel)
-
-        // Daemon status dot
-        daemonDot.translatesAutoresizingMaskIntoConstraints = false
-        daemonDot.wantsLayer = true
-        daemonDot.layer?.cornerRadius = 5
-        daemonDot.layer?.backgroundColor = NSColor.systemRed.cgColor
-        headerBar.addSubview(daemonDot)
-
-        // Daemon start/stop button
-        daemonButton.bezelStyle = .accessoryBarAction
-        daemonButton.title = "Start Daemon"
-        daemonButton.font = .systemFont(ofSize: 11)
-        daemonButton.isBordered = false
-        daemonButton.contentTintColor = Theme.primaryText
-        daemonButton.target = self
-        daemonButton.action = #selector(daemonToggleClicked)
-        daemonButton.translatesAutoresizingMaskIntoConstraints = false
-        headerBar.addSubview(daemonButton)
-
-        newButton.bezelStyle = .accessoryBarAction
-        newButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New Schedule")
-        newButton.title = "New Schedule"
-        newButton.imagePosition = .imageLeading
-        newButton.font = .systemFont(ofSize: 11)
-        newButton.isBordered = false
-        newButton.contentTintColor = Theme.primaryText
-        newButton.target = self
-        newButton.action = #selector(newScheduleClicked)
-        newButton.translatesAutoresizingMaskIntoConstraints = false
-        headerBar.addSubview(newButton)
-
-        let headerSep = NSBox()
-        headerSep.boxType = .separator
-        headerSep.translatesAutoresizingMaskIntoConstraints = false
-        headerBar.addSubview(headerSep)
-
-        addSubview(headerBar)
-
-        // Split view
-        splitView.isVertical = true
-        splitView.dividerStyle = .thin
-        splitView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(splitView)
-
-        // Left pane: table list
-        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("schedule"))
-        column.title = ""
-        tableView.addTableColumn(column)
-        tableView.headerView = nil
-        tableView.dataSource = self
-        tableView.delegate = self
-        tableView.rowSizeStyle = .medium
-        tableView.style = .sourceList
-        tableView.backgroundColor = .clear
-
-        listScrollView.documentView = tableView
-        listScrollView.hasVerticalScroller = true
-        listScrollView.drawsBackground = false
-        splitView.addSubview(listScrollView)
-
-        // Right pane: YAML editor
-        let editorContainer = NSView()
-        editorContainer.translatesAutoresizingMaskIntoConstraints = false
-
-        editorTextView.isEditable = true
-        editorTextView.isSelectable = true
-        editorTextView.isRichText = false
-        editorTextView.allowsUndo = true
-        editorTextView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        editorTextView.backgroundColor = Theme.contentBackground
-        editorTextView.textColor = Theme.primaryText
-        editorTextView.insertionPointColor = Theme.primaryText
-        editorTextView.isVerticallyResizable = true
-        editorTextView.isHorizontallyResizable = false
-        editorTextView.textContainer?.widthTracksTextView = true
-        editorTextView.textContainerInset = NSSize(width: 8, height: 8)
-        editorTextView.autoresizingMask = [.width, .height]
-        editorTextView.textStorage?.delegate = self
-
-        editorScrollView.documentView = editorTextView
-        editorScrollView.hasVerticalScroller = true
-        editorScrollView.drawsBackground = true
-        editorScrollView.backgroundColor = Theme.contentBackground
-        editorScrollView.translatesAutoresizingMaskIntoConstraints = false
-        editorContainer.addSubview(editorScrollView)
-
-        // Button bar at bottom of editor
-        let buttonBar = NSView()
-        buttonBar.translatesAutoresizingMaskIntoConstraints = false
-
-        let btnSep = NSBox()
-        btnSep.boxType = .separator
-        btnSep.translatesAutoresizingMaskIntoConstraints = false
-        buttonBar.addSubview(btnSep)
-
-        saveButton.bezelStyle = .accessoryBarAction
-        saveButton.title = "Save"
-        saveButton.image = NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: "Save")
-        saveButton.imagePosition = .imageLeading
-        saveButton.font = .systemFont(ofSize: 11)
-        saveButton.isBordered = false
-        saveButton.contentTintColor = Theme.primaryText
-        saveButton.target = self
-        saveButton.action = #selector(saveClicked)
-        saveButton.isEnabled = false
-        saveButton.translatesAutoresizingMaskIntoConstraints = false
-        buttonBar.addSubview(saveButton)
-
-        deleteButton.bezelStyle = .accessoryBarAction
-        deleteButton.title = "Delete"
-        deleteButton.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete")
-        deleteButton.imagePosition = .imageLeading
-        deleteButton.font = .systemFont(ofSize: 11)
-        deleteButton.isBordered = false
-        deleteButton.contentTintColor = .systemRed
-        deleteButton.target = self
-        deleteButton.action = #selector(deleteClicked)
-        deleteButton.isEnabled = false
-        deleteButton.translatesAutoresizingMaskIntoConstraints = false
-        buttonBar.addSubview(deleteButton)
-
-        editorContainer.addSubview(buttonBar)
-
-        NSLayoutConstraint.activate([
-            editorScrollView.topAnchor.constraint(equalTo: editorContainer.topAnchor),
-            editorScrollView.leadingAnchor.constraint(equalTo: editorContainer.leadingAnchor),
-            editorScrollView.trailingAnchor.constraint(equalTo: editorContainer.trailingAnchor),
-            editorScrollView.bottomAnchor.constraint(equalTo: buttonBar.topAnchor),
-
-            buttonBar.leadingAnchor.constraint(equalTo: editorContainer.leadingAnchor),
-            buttonBar.trailingAnchor.constraint(equalTo: editorContainer.trailingAnchor),
-            buttonBar.bottomAnchor.constraint(equalTo: editorContainer.bottomAnchor),
-            buttonBar.heightAnchor.constraint(equalToConstant: 36),
-
-            btnSep.topAnchor.constraint(equalTo: buttonBar.topAnchor),
-            btnSep.leadingAnchor.constraint(equalTo: buttonBar.leadingAnchor),
-            btnSep.trailingAnchor.constraint(equalTo: buttonBar.trailingAnchor),
-
-            saveButton.leadingAnchor.constraint(equalTo: buttonBar.leadingAnchor, constant: 8),
-            saveButton.centerYAnchor.constraint(equalTo: buttonBar.centerYAnchor),
-
-            deleteButton.trailingAnchor.constraint(equalTo: buttonBar.trailingAnchor, constant: -8),
-            deleteButton.centerYAnchor.constraint(equalTo: buttonBar.centerYAnchor),
-        ])
-
-        splitView.addSubview(editorContainer)
-
-        // Empty label
-        emptyLabel.font = .systemFont(ofSize: 14)
-        emptyLabel.textColor = .tertiaryLabelColor
-        emptyLabel.alignment = .center
-        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
-        emptyLabel.isHidden = true
-        addSubview(emptyLabel)
-
-        NSLayoutConstraint.activate([
-            headerBar.topAnchor.constraint(equalTo: topAnchor),
-            headerBar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            headerBar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            headerBar.heightAnchor.constraint(equalToConstant: 36),
-
-            headerLabel.leadingAnchor.constraint(equalTo: headerBar.leadingAnchor, constant: 12),
-            headerLabel.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
-
-            daemonDot.leadingAnchor.constraint(equalTo: headerLabel.trailingAnchor, constant: 8),
-            daemonDot.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
-            daemonDot.widthAnchor.constraint(equalToConstant: 10),
-            daemonDot.heightAnchor.constraint(equalToConstant: 10),
-
-            daemonButton.leadingAnchor.constraint(equalTo: daemonDot.trailingAnchor, constant: 4),
-            daemonButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
-
-            newButton.trailingAnchor.constraint(equalTo: headerBar.trailingAnchor, constant: -8),
-            newButton.centerYAnchor.constraint(equalTo: headerBar.centerYAnchor),
-
-            headerSep.bottomAnchor.constraint(equalTo: headerBar.bottomAnchor),
-            headerSep.leadingAnchor.constraint(equalTo: headerBar.leadingAnchor),
-            headerSep.trailingAnchor.constraint(equalTo: headerBar.trailingAnchor),
-
-            splitView.topAnchor.constraint(equalTo: headerBar.bottomAnchor),
-            splitView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            splitView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            splitView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            emptyLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            emptyLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-        ])
-
-        // Set initial split position
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.splitView.setPosition(220, ofDividerAt: 0)
-        }
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        layer?.backgroundColor = Theme.contentBackground.resolvedCGColor(for: effectiveAppearance)
-        editorTextView.backgroundColor = Theme.contentBackground
-        editorScrollView.backgroundColor = Theme.contentBackground
-    }
-
-    // MARK: - NSTableViewDataSource
-
-    func numberOfRows(in tableView: NSTableView) -> Int {
-        schedules.count
-    }
-
-    // MARK: - NSTableViewDelegate
-
-    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-        guard row < schedules.count else { return nil }
-        let schedule = schedules[row]
-
-        let cell = NSTableCellView()
-        let stack = NSStackView()
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = 2
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        let nameLabel = NSTextField(labelWithString: schedule.name)
-        nameLabel.font = .boldSystemFont(ofSize: 12)
-        nameLabel.textColor = Theme.primaryText
-
-        let typeIcon = schedule.type == "swarm" ? "S" : "P"
-        let detail = "[\(typeIcon)] \(schedule.cronExpression) \u{2192} \(schedule.target)"
-        let detailLabel = NSTextField(labelWithString: "\(schedule.projectName) \u{00B7} \(detail)")
-        detailLabel.font = .systemFont(ofSize: 10)
-        detailLabel.textColor = .secondaryLabelColor
-        detailLabel.lineBreakMode = .byTruncatingTail
-
-        stack.addArrangedSubview(nameLabel)
-        stack.addArrangedSubview(detailLabel)
-
-        cell.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
-            stack.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -4),
-            stack.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-        ])
-        return cell
-    }
-
-    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        38
-    }
-
-    func tableViewSelectionDidChange(_ notification: Notification) {
-        let row = tableView.selectedRow
-        guard row >= 0, row < schedules.count else {
-            selectedIndex = nil
-            editorTextView.string = ""
-            loadedFilePath = nil
-            saveButton.isEnabled = false
-            deleteButton.isEnabled = false
-            return
-        }
-        selectedIndex = row
-        loadScheduleFile(at: row)
-        saveButton.isEnabled = true
-        deleteButton.isEnabled = true
-    }
-
-    // MARK: - Editor
-
-    private func loadScheduleFile(at index: Int) {
-        let schedule = schedules[index]
-        let content = (try? String(contentsOfFile: schedule.filePath, encoding: .utf8)) ?? ""
-        editorTextView.string = content
-        loadedFilePath = schedule.filePath
-        isDirty = false
-        highlightYAML()
-    }
-
-    // MARK: - NSTextStorageDelegate (YAML key highlighting)
-
-    func textStorage(_ textStorage: NSTextStorage, didProcessEditing editedMask: NSTextStorageEditActions, range editedRange: NSRange, changeInLength delta: Int) {
-        guard editedMask.contains(.editedCharacters) else { return }
-        isDirty = true
-        highlightYAML()
-    }
-
-    private func highlightYAML() {
-        guard let storage = editorTextView.textStorage else { return }
-        let fullRange = NSRange(location: 0, length: storage.length)
-        let monoFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        let boldFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .bold)
-
-        storage.beginEditing()
-        storage.addAttributes([
-            .foregroundColor: Theme.primaryText,
-            .font: monoFont,
-        ], range: fullRange)
-
-        let text = storage.string
-
-        // Highlight YAML keys (word followed by colon at start of line or after spaces)
-        if let keyRegex = try? NSRegularExpression(pattern: "^(\\s*-?\\s*)(\\w+):", options: .anchorsMatchLines) {
-            let matches = keyRegex.matches(in: text, range: fullRange)
-            for match in matches {
-                if match.numberOfRanges > 2 {
-                    storage.addAttributes([
-                        .foregroundColor: NSColor.systemBlue,
-                        .font: boldFont,
-                    ], range: match.range(at: 2))
-                }
-            }
-        }
-
-        // Highlight cron expressions (quoted strings)
-        if let quotedRegex = try? NSRegularExpression(pattern: "'[^']*'|\"[^\"]*\"") {
-            let matches = quotedRegex.matches(in: text, range: fullRange)
-            for match in matches {
-                storage.addAttributes([
-                    .foregroundColor: NSColor.systemOrange,
-                    .font: monoFont,
-                ], range: match.range)
-            }
-        }
-
-        storage.endEditing()
-    }
-
-    // MARK: - Actions
-
-    @objc private func saveClicked() {
-        guard let path = loadedFilePath else { return }
-        let content = editorTextView.string
-        do {
-            try content.write(toFile: path, atomically: true, encoding: .utf8)
-            isDirty = false
-            // Rescan to update the list
-            configure(projects: projects)
-        } catch {
-            let alert = NSAlert()
-            alert.messageText = "Failed to Save"
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .warning
-            alert.runModal()
-        }
-    }
-
-    @objc private func deleteClicked() {
-        guard let idx = selectedIndex, idx < schedules.count else { return }
-        let schedule = schedules[idx]
-
-        let alert = NSAlert()
-        alert.messageText = "Delete schedule \"\(schedule.name)\"?"
-        alert.informativeText = "This will remove the schedule entry from schedules.yaml. If it's the only entry, the file will be deleted."
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Delete")
-        alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-
-        // Remove the entry from the YAML by filtering out lines for this schedule
-        // Simplest approach: reload, remove the schedule block, save
-        guard let content = try? String(contentsOfFile: schedule.filePath, encoding: .utf8) else { return }
-        let filtered = removeScheduleEntry(named: schedule.name, from: content)
-
-        do {
-            if filtered.trimmingCharacters(in: .whitespacesAndNewlines) == "schedules:" ||
-               filtered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                try FileManager.default.removeItem(atPath: schedule.filePath)
-            } else {
-                try filtered.write(toFile: schedule.filePath, atomically: true, encoding: .utf8)
-            }
-            selectedIndex = nil
-            editorTextView.string = ""
-            loadedFilePath = nil
-            saveButton.isEnabled = false
-            deleteButton.isEnabled = false
-            configure(projects: projects)
-        } catch {
-            let errAlert = NSAlert()
-            errAlert.messageText = "Failed to Delete"
-            errAlert.informativeText = error.localizedDescription
-            errAlert.alertStyle = .warning
-            errAlert.runModal()
-        }
-    }
-
-    /// Remove a named schedule entry from the YAML content.
-    private func removeScheduleEntry(named name: String, from content: String) -> String {
-        let lines = content.components(separatedBy: "\n")
-        var result: [String] = []
-        var skipping = false
-
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            // Detect start of a schedule entry (list item)
-            if trimmed.hasPrefix("- ") && (trimmed.contains("name:") && trimmed.contains(name)) {
-                skipping = true
-                continue
-            }
-            if trimmed.hasPrefix("- name:") && Self.yamlValue(trimmed.replacingOccurrences(of: "- ", with: "")) == name {
-                skipping = true
-                continue
-            }
-            // If we're in a "- name: X" block, detect the start of the entry
-            if trimmed == "- name: \(name)" || trimmed == "- name: '\(name)'" || trimmed == "- name: \"\(name)\"" {
-                skipping = true
-                continue
-            }
-            // Stop skipping when we hit the next list item or a top-level key
-            if skipping {
-                if trimmed.hasPrefix("- ") || (!line.hasPrefix(" ") && !line.hasPrefix("\t") && !trimmed.isEmpty && !trimmed.hasPrefix("#")) {
-                    skipping = false
-                } else {
-                    continue
-                }
-            }
-            result.append(line)
-        }
-        return result.joined(separator: "\n")
-    }
-
-    @objc private func daemonToggleClicked() {
-        guard let ctx = projects.first else { return }
-        let command = daemonRunning ? "cron stop" : "cron start"
-        let projectRoot = ctx.projectRoot
-        daemonButton.isEnabled = false
-
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            _ = PPGService.shared.runPPGCommand(command, projectRoot: projectRoot)
-            DispatchQueue.main.async {
-                self?.daemonButton.isEnabled = true
-                self?.checkDaemonStatus()
-            }
-        }
-    }
-
-    @objc private func newScheduleClicked() {
+    private func showNewScheduleDialog(prefilledDate: Date?) {
         guard !projects.isEmpty else { return }
 
         let alert = NSAlert()
@@ -682,23 +791,22 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
         alert.addButton(withTitle: "Create")
         alert.addButton(withTitle: "Cancel")
 
-        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 260))
-
-        var y: CGFloat = 260
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 300))
+        var y: CGFloat = 300
 
         func addLabel(_ text: String) {
-            y -= 16
+            y -= 18
             let label = NSTextField(labelWithString: text)
             label.font = .systemFont(ofSize: 11, weight: .medium)
             label.textColor = .secondaryLabelColor
-            label.frame = NSRect(x: 0, y: y, width: 260, height: 16)
+            label.frame = NSRect(x: 0, y: y, width: 300, height: 16)
             accessory.addSubview(label)
             y -= 2
         }
 
         func addPopup(_ items: [String]) -> NSPopUpButton {
-            y -= 24
-            let popup = NSPopUpButton(frame: NSRect(x: 0, y: y, width: 260, height: 24), pullsDown: false)
+            y -= 26
+            let popup = NSPopUpButton(frame: NSRect(x: 0, y: y, width: 300, height: 24), pullsDown: false)
             for item in items { popup.addItem(withTitle: item) }
             accessory.addSubview(popup)
             y -= 8
@@ -706,31 +814,58 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
         }
 
         addLabel("Name:")
-        y -= 24
-        let nameField = NSTextField(frame: NSRect(x: 0, y: y, width: 260, height: 24))
+        y -= 26
+        let nameField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
         nameField.placeholderString = "schedule-name"
         accessory.addSubview(nameField)
-        y -= 12
+        y -= 10
 
         addLabel("Cron Expression:")
-        y -= 24
-        let cronField = NSTextField(frame: NSRect(x: 0, y: y, width: 260, height: 24))
-        cronField.placeholderString = "0 * * * *"
+        y -= 26
+        let cronField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
+
+        // Pre-fill cron from date if provided
+        if let date = prefilledDate {
+            let cal = Calendar.current
+            let minute = cal.component(.minute, from: date)
+            let hour = cal.component(.hour, from: date)
+            cronField.stringValue = "\(minute) \(hour) * * *"
+        } else {
+            cronField.placeholderString = "0 9 * * *"
+        }
         accessory.addSubview(cronField)
-        y -= 12
+        y -= 4
+
+        // Live preview label
+        let previewLabel = NSTextField(labelWithString: "")
+        previewLabel.font = .systemFont(ofSize: 10)
+        previewLabel.textColor = .tertiaryLabelColor
+        y -= 14
+        previewLabel.frame = NSRect(x: 0, y: y, width: 300, height: 14)
+        accessory.addSubview(previewLabel)
+        y -= 6
 
         addLabel("Type:")
         let typePopup = addPopup(["swarm", "prompt"])
 
         addLabel("Target (template name):")
-        y -= 24
-        let targetField = NSTextField(frame: NSRect(x: 0, y: y, width: 260, height: 24))
+        y -= 26
+        let targetField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
         targetField.placeholderString = "template-name"
         accessory.addSubview(targetField)
-        y -= 12
+        y -= 10
 
         addLabel("Project:")
         let projectPopup = addPopup(projects.map { $0.projectName.isEmpty ? $0.projectRoot : $0.projectName })
+
+        // Update preview on cron field change (using delegate would be ideal, but simpler to just show on dialog open)
+        if let expr = try? CronParser.parse(cronField.stringValue),
+           let next = CronParser.nextOccurrence(of: expr, after: Date()) {
+            let fmt = DateFormatter()
+            fmt.dateStyle = .medium
+            fmt.timeStyle = .short
+            previewLabel.stringValue = "Next: \(fmt.string(from: next))"
+        }
 
         alert.accessoryView = accessory
         alert.window.initialFirstResponder = nameField
@@ -755,29 +890,18 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
         }
 
         let filePath = (ppgDir as NSString).appendingPathComponent("schedules.yaml")
-
-        // Build the new entry YAML
         let entry = "  - name: \(name)\n    \(type): \(target)\n    cron: '\(cron)'\n"
 
         do {
             if fm.fileExists(atPath: filePath),
                let existing = try? String(contentsOfFile: filePath, encoding: .utf8) {
-                // Append to existing file
                 let updated = existing.hasSuffix("\n") ? existing + entry : existing + "\n" + entry
                 try updated.write(toFile: filePath, atomically: true, encoding: .utf8)
             } else {
-                // Create new file
                 let content = "schedules:\n" + entry
                 try content.write(toFile: filePath, atomically: true, encoding: .utf8)
             }
-
             configure(projects: projects)
-            // Select the new schedule
-            if let idx = schedules.firstIndex(where: { $0.name == name && $0.filePath == filePath }) {
-                tableView.selectRowIndexes(IndexSet(integer: idx), byExtendingSelection: false)
-                loadScheduleFile(at: idx)
-                selectedIndex = idx
-            }
         } catch {
             let errAlert = NSAlert()
             errAlert.messageText = "Failed to Create"
@@ -785,5 +909,897 @@ class SchedulesView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextS
             errAlert.alertStyle = .warning
             errAlert.runModal()
         }
+    }
+
+    private func showEditScheduleDialog(at index: Int) {
+        guard index < schedules.count, !projects.isEmpty else { return }
+        let schedule = schedules[index]
+
+        let alert = NSAlert()
+        alert.messageText = "Edit Schedule"
+        alert.informativeText = ""
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 220))
+        var y: CGFloat = 220
+
+        func addLabel(_ text: String) {
+            y -= 18
+            let label = NSTextField(labelWithString: text)
+            label.font = .systemFont(ofSize: 11, weight: .medium)
+            label.textColor = .secondaryLabelColor
+            label.frame = NSRect(x: 0, y: y, width: 300, height: 16)
+            accessory.addSubview(label)
+            y -= 2
+        }
+
+        addLabel("Name:")
+        y -= 26
+        let nameField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
+        nameField.stringValue = schedule.name
+        accessory.addSubview(nameField)
+        y -= 10
+
+        addLabel("Cron Expression:")
+        y -= 26
+        let cronField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
+        cronField.stringValue = schedule.cronExpression
+        accessory.addSubview(cronField)
+        y -= 10
+
+        addLabel("Type:")
+        y -= 26
+        let typePopup = NSPopUpButton(frame: NSRect(x: 0, y: y, width: 300, height: 24), pullsDown: false)
+        typePopup.addItem(withTitle: "swarm")
+        typePopup.addItem(withTitle: "prompt")
+        typePopup.selectItem(withTitle: schedule.type)
+        accessory.addSubview(typePopup)
+        y -= 10
+
+        addLabel("Target:")
+        y -= 26
+        let targetField = NSTextField(frame: NSRect(x: 0, y: y, width: 300, height: 24))
+        targetField.stringValue = schedule.target
+        accessory.addSubview(targetField)
+
+        alert.accessoryView = accessory
+        alert.window.initialFirstResponder = nameField
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let newName = nameField.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !newName.isEmpty else { return }
+        let newCron = cronField.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !newCron.isEmpty else { return }
+        let newType = typePopup.titleOfSelectedItem ?? schedule.type
+        let newTarget = targetField.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !newTarget.isEmpty else { return }
+
+        guard let content = try? String(contentsOfFile: schedule.filePath, encoding: .utf8) else { return }
+        let withoutOld = removeScheduleEntry(named: schedule.name, from: content)
+        let newEntry = "  - name: \(newName)\n    \(newType): \(newTarget)\n    cron: '\(newCron)'\n"
+        let updated = withoutOld.hasSuffix("\n") ? withoutOld + newEntry : withoutOld + "\n" + newEntry
+
+        do {
+            try updated.write(toFile: schedule.filePath, atomically: true, encoding: .utf8)
+            configure(projects: projects)
+        } catch {
+            let errAlert = NSAlert()
+            errAlert.messageText = "Failed to Save"
+            errAlert.informativeText = error.localizedDescription
+            errAlert.alertStyle = .warning
+            errAlert.runModal()
+        }
+    }
+
+    /// Remove a named schedule entry from the YAML content.
+    private func removeScheduleEntry(named name: String, from content: String) -> String {
+        let lines = content.components(separatedBy: "\n")
+        var result: [String] = []
+        var skipping = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("- ") && trimmed.contains("name:") && trimmed.contains(name) {
+                skipping = true; continue
+            }
+            if trimmed.hasPrefix("- name:") && Self.yamlValue(trimmed.replacingOccurrences(of: "- ", with: "")) == name {
+                skipping = true; continue
+            }
+            if trimmed == "- name: \(name)" || trimmed == "- name: '\(name)'" || trimmed == "- name: \"\(name)\"" {
+                skipping = true; continue
+            }
+            if skipping {
+                if trimmed.hasPrefix("- ") || (!line.hasPrefix(" ") && !line.hasPrefix("\t") && !trimmed.isEmpty && !trimmed.hasPrefix("#")) {
+                    skipping = false
+                } else {
+                    continue
+                }
+            }
+            result.append(line)
+        }
+        return result.joined(separator: "\n")
+    }
+}
+
+// MARK: - CalendarMonthView
+
+class CalendarMonthView: NSView {
+
+    var onDayClicked: ((Date) -> Void)?
+    var onEventClicked: ((CalendarEvent, NSView) -> Void)?
+
+    private let dayHeaders = ["S", "M", "T", "W", "T", "F", "S"]
+    private var dayCells: [DayCellView] = []
+    private var headerLabels: [NSTextField] = []
+    private let gridContainer = NSView()
+    private let headerRow = NSView()
+
+    private var currentDate = Date()
+    private var events: [CalendarEvent] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupGrid()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupGrid()
+    }
+
+    func configure(currentDate: Date, events: [CalendarEvent]) {
+        self.currentDate = currentDate
+        self.events = events
+        layoutDays()
+    }
+
+    private func setupGrid() {
+        wantsLayer = true
+
+        // Day-of-week headers
+        headerRow.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(headerRow)
+
+        for (_, day) in dayHeaders.enumerated() {
+            let label = NSTextField(labelWithString: day)
+            label.font = .systemFont(ofSize: 11, weight: .medium)
+            label.textColor = .tertiaryLabelColor
+            label.alignment = .center
+            label.translatesAutoresizingMaskIntoConstraints = false
+            headerRow.addSubview(label)
+            headerLabels.append(label)
+        }
+
+        // Grid of 42 cells (6 rows x 7 cols)
+        gridContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(gridContainer)
+
+        for _ in 0..<42 {
+            let cell = DayCellView()
+            cell.translatesAutoresizingMaskIntoConstraints = false
+            gridContainer.addSubview(cell)
+            dayCells.append(cell)
+        }
+
+        NSLayoutConstraint.activate([
+            headerRow.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            headerRow.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerRow.trailingAnchor.constraint(equalTo: trailingAnchor),
+            headerRow.heightAnchor.constraint(equalToConstant: 20),
+
+            gridContainer.topAnchor.constraint(equalTo: headerRow.bottomAnchor, constant: 2),
+            gridContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            gridContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            gridContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    override func layout() {
+        super.layout()
+        let w = bounds.width
+        let cellW = w / 7.0
+
+        // Position header labels
+        for (i, label) in headerLabels.enumerated() {
+            label.frame = NSRect(x: CGFloat(i) * cellW, y: 0, width: cellW, height: 20)
+        }
+
+        // Position day cells
+        let gridH = gridContainer.bounds.height
+        let cellH = gridH / 6.0
+        for i in 0..<42 {
+            let row = i / 7
+            let col = i % 7
+            let x = CGFloat(col) * cellW
+            let y = gridH - CGFloat(row + 1) * cellH
+            dayCells[i].frame = NSRect(x: x, y: y, width: cellW, height: cellH)
+        }
+    }
+
+    private func layoutDays() {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: currentDate)
+        let firstOfMonth = cal.date(from: comps)!
+        let currentMonth = cal.component(.month, from: currentDate)
+
+        let firstWeekday = cal.component(.weekday, from: firstOfMonth) // 1=Sun
+        let startOffset = -(firstWeekday - cal.firstWeekday + 7) % 7
+        let gridStart = cal.date(byAdding: .day, value: startOffset, to: firstOfMonth)!
+
+        let today = cal.startOfDay(for: Date())
+
+        for i in 0..<42 {
+            let cellDate = cal.date(byAdding: .day, value: i, to: gridStart)!
+            let cellMonth = cal.component(.month, from: cellDate)
+            let isCurrentMonth = cellMonth == currentMonth
+            let isToday = cal.isDate(cellDate, inSameDayAs: today)
+
+            // Find events for this day
+            let dayStart = cal.startOfDay(for: cellDate)
+            let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart)!
+            let dayEvents = events.filter { $0.date >= dayStart && $0.date < dayEnd }
+
+            dayCells[i].configure(
+                day: cal.component(.day, from: cellDate),
+                date: cellDate,
+                isCurrentMonth: isCurrentMonth,
+                isToday: isToday,
+                events: dayEvents
+            )
+            dayCells[i].onClicked = { [weak self] date in
+                self?.onDayClicked?(date)
+            }
+            dayCells[i].onEventClicked = { [weak self] event, view in
+                self?.onEventClicked?(event, view)
+            }
+        }
+    }
+}
+
+// MARK: - DayCellView (Month Grid Cell)
+
+private class DayCellView: NSView {
+
+    var onClicked: ((Date) -> Void)?
+    var onEventClicked: ((CalendarEvent, NSView) -> Void)?
+
+    private let dayLabel = NSTextField(labelWithString: "")
+    private var eventPills: [EventPillView] = []
+    private let moreLabel = NSTextField(labelWithString: "")
+    private var cellDate = Date()
+    private var isToday = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.borderWidth = 0.5
+        layer?.borderColor = NSColor.separatorColor.cgColor
+
+        dayLabel.font = .systemFont(ofSize: 11)
+        dayLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(dayLabel)
+
+        moreLabel.font = .systemFont(ofSize: 9)
+        moreLabel.textColor = .tertiaryLabelColor
+        moreLabel.translatesAutoresizingMaskIntoConstraints = false
+        moreLabel.isHidden = true
+        addSubview(moreLabel)
+
+        NSLayoutConstraint.activate([
+            dayLabel.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            dayLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+        ])
+
+        let click = NSClickGestureRecognizer(target: self, action: #selector(cellClicked))
+        addGestureRecognizer(click)
+    }
+
+    func configure(day: Int, date: Date, isCurrentMonth: Bool, isToday: Bool, events: [CalendarEvent]) {
+        self.cellDate = date
+        self.isToday = isToday
+        dayLabel.stringValue = "\(day)"
+        dayLabel.textColor = isCurrentMonth ? Theme.primaryText : .tertiaryLabelColor
+
+        if isToday {
+            dayLabel.font = .boldSystemFont(ofSize: 11)
+            layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.08).cgColor
+        } else {
+            dayLabel.font = .systemFont(ofSize: 11)
+            layer?.backgroundColor = nil
+        }
+
+        // Clear old pills
+        eventPills.forEach { $0.removeFromSuperview() }
+        eventPills.removeAll()
+        moreLabel.isHidden = true
+
+        // Show up to 3 event pills
+        let maxVisible = 3
+        let unique = deduplicateEvents(events)
+        let visible = Array(unique.prefix(maxVisible))
+
+        var pillY: CGFloat = bounds.height - 20
+
+        for event in visible {
+            let pill = EventPillView()
+            pill.configure(event: event)
+            pill.frame = NSRect(x: 2, y: pillY - 14, width: bounds.width - 4, height: 14)
+            pill.autoresizingMask = [.width]
+            pill.onClicked = { [weak self] ev in
+                self?.onEventClicked?(ev, pill)
+            }
+            addSubview(pill)
+            eventPills.append(pill)
+            pillY -= 15
+        }
+
+        if unique.count > maxVisible {
+            moreLabel.stringValue = "+\(unique.count - maxVisible) more"
+            moreLabel.isHidden = false
+            moreLabel.frame = NSRect(x: 4, y: pillY - 12, width: bounds.width - 8, height: 12)
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        // Reposition pills on resize
+        var pillY: CGFloat = bounds.height - 20
+        for pill in eventPills {
+            pill.frame = NSRect(x: 2, y: pillY - 14, width: bounds.width - 4, height: 14)
+            pillY -= 15
+        }
+        if !moreLabel.isHidden {
+            moreLabel.frame = NSRect(x: 4, y: pillY - 12, width: bounds.width - 8, height: 12)
+        }
+    }
+
+    private func deduplicateEvents(_ events: [CalendarEvent]) -> [CalendarEvent] {
+        // Group high-frequency events by schedule name
+        var seen = Set<String>()
+        var result: [CalendarEvent] = []
+        for event in events {
+            let key = "\(event.schedule.name)-\(event.schedule.filePath)"
+            if event.isHighFrequency {
+                if !seen.contains(key) {
+                    seen.insert(key)
+                    result.append(event)
+                }
+            } else {
+                if !seen.contains(key) {
+                    seen.insert(key)
+                    result.append(event)
+                }
+            }
+        }
+        return result
+    }
+
+    @objc private func cellClicked() {
+        onClicked?(cellDate)
+    }
+}
+
+// MARK: - EventPillView
+
+private class EventPillView: NSView {
+
+    var onClicked: ((CalendarEvent) -> Void)?
+    private var event: CalendarEvent?
+    private let label = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = 3
+
+        label.font = .systemFont(ofSize: 9, weight: .medium)
+        label.textColor = .white
+        label.lineBreakMode = .byTruncatingTail
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 3),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        let click = NSClickGestureRecognizer(target: self, action: #selector(pillClicked))
+        addGestureRecognizer(click)
+    }
+
+    func configure(event: CalendarEvent) {
+        self.event = event
+        let typeIcon = event.schedule.type == "swarm" ? "S" : "P"
+        let suffix = event.isHighFrequency ? " (recurring)" : ""
+        label.stringValue = "[\(typeIcon)] \(event.schedule.name)\(suffix)"
+        layer?.backgroundColor = event.color.withAlphaComponent(0.85).cgColor
+    }
+
+    @objc private func pillClicked() {
+        guard let event = event else { return }
+        onClicked?(event)
+    }
+}
+
+// MARK: - CalendarWeekView
+
+class CalendarWeekView: NSView {
+
+    var onEventClicked: ((CalendarEvent, NSView) -> Void)?
+    var onEmptySlotClicked: ((Date) -> Void)?
+
+    private let scrollView = NSScrollView()
+    private let contentView = NSView()
+    private let headerRow = NSView()
+    private let gutterWidth: CGFloat = 50
+    private let hourHeight: CGFloat = 50
+    private let headerHeight: CGFloat = 28
+    private var nowLine: NSView?
+    private var eventViews: [NSView] = []
+
+    private var currentDate = Date()
+    private var events: [CalendarEvent] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    func configure(currentDate: Date, events: [CalendarEvent]) {
+        self.currentDate = currentDate
+        self.events = events
+        layoutWeek()
+    }
+
+    private func setupView() {
+        wantsLayer = true
+
+        // Header row (day labels)
+        headerRow.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(headerRow)
+
+        // Scrollable time grid
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        addSubview(scrollView)
+
+        let totalHeight = hourHeight * 24
+        contentView.frame = NSRect(x: 0, y: 0, width: 1, height: totalHeight)
+        scrollView.documentView = contentView
+
+        NSLayoutConstraint.activate([
+            headerRow.topAnchor.constraint(equalTo: topAnchor),
+            headerRow.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerRow.trailingAnchor.constraint(equalTo: trailingAnchor),
+            headerRow.heightAnchor.constraint(equalToConstant: headerHeight),
+
+            scrollView.topAnchor.constraint(equalTo: headerRow.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func layoutWeek() {
+        // Clear previous
+        contentView.subviews.forEach { $0.removeFromSuperview() }
+        headerRow.subviews.forEach { $0.removeFromSuperview() }
+        eventViews.removeAll()
+
+        let cal = Calendar.current
+        let weekday = cal.component(.weekday, from: currentDate)
+        let startOffset = -(weekday - cal.firstWeekday + 7) % 7
+        let weekStart = cal.date(byAdding: .day, value: startOffset, to: currentDate)!
+
+        let totalHeight = hourHeight * 24
+        let width = bounds.width
+        contentView.frame = NSRect(x: 0, y: 0, width: max(width, 100), height: totalHeight)
+
+        let dayWidth = (width - gutterWidth) / 7.0
+        let today = cal.startOfDay(for: Date())
+        let fmt = DateFormatter()
+        fmt.dateFormat = "EEE d"
+
+        // Draw day headers
+        for col in 0..<7 {
+            let day = cal.date(byAdding: .day, value: col, to: weekStart)!
+            let isToday = cal.isDate(day, inSameDayAs: today)
+            let label = NSTextField(labelWithString: fmt.string(from: day))
+            label.font = isToday ? .boldSystemFont(ofSize: 11) : .systemFont(ofSize: 11)
+            label.textColor = isToday ? .controlAccentColor : Theme.primaryText
+            label.alignment = .center
+            label.frame = NSRect(x: gutterWidth + CGFloat(col) * dayWidth, y: 0, width: dayWidth, height: headerHeight)
+            headerRow.addSubview(label)
+        }
+
+        // Draw hour lines and labels
+        for hour in 0..<24 {
+            let y = totalHeight - CGFloat(hour + 1) * hourHeight
+            let label = NSTextField(labelWithString: String(format: "%02d:00", hour))
+            label.font = .systemFont(ofSize: 9)
+            label.textColor = .tertiaryLabelColor
+            label.alignment = .right
+            label.frame = NSRect(x: 0, y: y + hourHeight - 10, width: gutterWidth - 6, height: 14)
+            contentView.addSubview(label)
+
+            let line = NSView(frame: NSRect(x: gutterWidth, y: y + hourHeight, width: width - gutterWidth, height: 1))
+            line.wantsLayer = true
+            line.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.3).cgColor
+            line.autoresizingMask = [.width]
+            contentView.addSubview(line)
+        }
+
+        // Draw vertical day separators
+        for col in 0...7 {
+            let x = gutterWidth + CGFloat(col) * dayWidth
+            let sep = NSView(frame: NSRect(x: x, y: 0, width: 1, height: totalHeight))
+            sep.wantsLayer = true
+            sep.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.2).cgColor
+            contentView.addSubview(sep)
+        }
+
+        // Place events
+        for col in 0..<7 {
+            let day = cal.date(byAdding: .day, value: col, to: weekStart)!
+            let dayStart = cal.startOfDay(for: day)
+            let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart)!
+            let dayEvents = events.filter { $0.date >= dayStart && $0.date < dayEnd && !$0.isHighFrequency }
+
+            for event in dayEvents {
+                let comps = cal.dateComponents([.hour, .minute], from: event.date)
+                let minuteOffset = CGFloat(comps.hour! * 60 + comps.minute!)
+                let y = totalHeight - (minuteOffset / 60.0) * hourHeight - 25
+                let x = gutterWidth + CGFloat(col) * dayWidth + 2
+                let eventW = dayWidth - 4
+
+                let eventView = makeEventBlock(event: event, frame: NSRect(x: x, y: y, width: eventW, height: 25))
+                contentView.addSubview(eventView)
+                eventViews.append(eventView)
+            }
+
+            // High-frequency events: show banner at top of day
+            let hfEvents = events.filter { $0.date >= dayStart && $0.date < dayEnd && $0.isHighFrequency }
+            var hfSeen = Set<String>()
+            for event in hfEvents {
+                let key = "\(event.schedule.name)"
+                guard !hfSeen.contains(key) else { continue }
+                hfSeen.insert(key)
+                let x = gutterWidth + CGFloat(col) * dayWidth + 2
+                let y = totalHeight - 16
+                let eventView = makeEventBlock(event: event, frame: NSRect(x: x, y: y, width: dayWidth - 4, height: 14))
+                contentView.addSubview(eventView)
+                eventViews.append(eventView)
+            }
+        }
+
+        // "Now" line
+        let nowComps = cal.dateComponents([.hour, .minute], from: Date())
+        let nowMinute = CGFloat(nowComps.hour! * 60 + nowComps.minute!)
+        let nowY = totalHeight - (nowMinute / 60.0) * hourHeight
+        let line = NSView(frame: NSRect(x: gutterWidth, y: nowY, width: width - gutterWidth, height: 2))
+        line.wantsLayer = true
+        line.layer?.backgroundColor = NSColor.systemRed.cgColor
+        line.autoresizingMask = [.width]
+        contentView.addSubview(line)
+        nowLine = line
+
+        // Add click recognizer for empty slots
+        let click = NSClickGestureRecognizer(target: self, action: #selector(gridClicked(_:)))
+        contentView.addGestureRecognizer(click)
+
+        // Auto-scroll to 8 AM
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let scrollY = totalHeight - 8 * self.hourHeight - self.scrollView.bounds.height / 2
+            self.scrollView.contentView.scroll(to: NSPoint(x: 0, y: max(0, scrollY)))
+        }
+    }
+
+    private func makeEventBlock(event: CalendarEvent, frame: NSRect) -> NSView {
+        let view = NSView(frame: frame)
+        view.wantsLayer = true
+        view.layer?.cornerRadius = 4
+        view.layer?.backgroundColor = event.color.withAlphaComponent(0.85).cgColor
+
+        let label = NSTextField(labelWithString: event.schedule.name)
+        label.font = .systemFont(ofSize: 10, weight: .medium)
+        label.textColor = .white
+        label.lineBreakMode = .byTruncatingTail
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 4),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -4),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        let click = NSClickGestureRecognizer(target: self, action: #selector(eventBlockClicked(_:)))
+        view.addGestureRecognizer(click)
+
+        // Store event reference
+        objc_setAssociatedObject(view, &CalendarWeekView.eventKey, event.schedule.name, .OBJC_ASSOCIATION_RETAIN)
+        return view
+    }
+
+    private static var eventKey: UInt8 = 0
+
+    @objc private func eventBlockClicked(_ sender: NSClickGestureRecognizer) {
+        guard let view = sender.view,
+              let name = objc_getAssociatedObject(view, &CalendarWeekView.eventKey) as? String,
+              let event = events.first(where: { $0.schedule.name == name }) else { return }
+        onEventClicked?(event, view)
+    }
+
+    @objc private func gridClicked(_ sender: NSClickGestureRecognizer) {
+        let location = sender.location(in: contentView)
+        let totalHeight = hourHeight * 24
+        let width = bounds.width
+        let dayWidth = (width - gutterWidth) / 7.0
+
+        guard location.x > gutterWidth else { return }
+        let col = Int((location.x - gutterWidth) / dayWidth)
+        guard col >= 0, col < 7 else { return }
+
+        let minuteFromTop = (totalHeight - location.y) / hourHeight * 60
+        let hour = Int(minuteFromTop / 60)
+        let minute = (Int(minuteFromTop) % 60 / 30) * 30 // Snap to 30min
+
+        let cal = Calendar.current
+        let weekday = cal.component(.weekday, from: currentDate)
+        let startOffset = -(weekday - cal.firstWeekday + 7) % 7
+        let weekStart = cal.date(byAdding: .day, value: startOffset, to: currentDate)!
+        let clickedDay = cal.date(byAdding: .day, value: col, to: weekStart)!
+
+        var comps = cal.dateComponents([.year, .month, .day], from: clickedDay)
+        comps.hour = max(0, min(23, hour))
+        comps.minute = max(0, min(59, minute))
+
+        if let date = cal.date(from: comps) {
+            onEmptySlotClicked?(date)
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        layoutWeek()
+    }
+}
+
+// MARK: - CalendarDayView
+
+class CalendarDayView: NSView {
+
+    var onEventClicked: ((CalendarEvent, NSView) -> Void)?
+    var onEmptySlotClicked: ((Date) -> Void)?
+
+    private let scrollView = NSScrollView()
+    private let contentView = NSView()
+    private let gutterWidth: CGFloat = 60
+    private let hourHeight: CGFloat = 60
+    private var eventViews: [NSView] = []
+
+    private var currentDate = Date()
+    private var events: [CalendarEvent] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    func configure(currentDate: Date, events: [CalendarEvent]) {
+        self.currentDate = currentDate
+        self.events = events
+        layoutDay()
+    }
+
+    private func setupView() {
+        wantsLayer = true
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        addSubview(scrollView)
+
+        let totalHeight = hourHeight * 24
+        contentView.frame = NSRect(x: 0, y: 0, width: 1, height: totalHeight)
+        scrollView.documentView = contentView
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func layoutDay() {
+        contentView.subviews.forEach { $0.removeFromSuperview() }
+        eventViews.removeAll()
+
+        let cal = Calendar.current
+        let totalHeight = hourHeight * 24
+        let width = bounds.width
+        contentView.frame = NSRect(x: 0, y: 0, width: max(width, 100), height: totalHeight)
+
+        let dayStart = cal.startOfDay(for: currentDate)
+        let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart)!
+
+        // Hour lines and labels
+        for hour in 0..<24 {
+            let y = totalHeight - CGFloat(hour + 1) * hourHeight
+            let label = NSTextField(labelWithString: String(format: "%02d:00", hour))
+            label.font = .systemFont(ofSize: 10)
+            label.textColor = .tertiaryLabelColor
+            label.alignment = .right
+            label.frame = NSRect(x: 0, y: y + hourHeight - 10, width: gutterWidth - 8, height: 14)
+            contentView.addSubview(label)
+
+            let line = NSView(frame: NSRect(x: gutterWidth, y: y + hourHeight, width: width - gutterWidth, height: 1))
+            line.wantsLayer = true
+            line.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.3).cgColor
+            line.autoresizingMask = [.width]
+            contentView.addSubview(line)
+        }
+
+        // Events for this day
+        let dayEvents = events.filter { $0.date >= dayStart && $0.date < dayEnd && !$0.isHighFrequency }
+        let eventWidth = width - gutterWidth - 20
+
+        for event in dayEvents {
+            let comps = cal.dateComponents([.hour, .minute], from: event.date)
+            let minuteOffset = CGFloat(comps.hour! * 60 + comps.minute!)
+            let y = totalHeight - (minuteOffset / 60.0) * hourHeight - 30
+
+            let view = NSView(frame: NSRect(x: gutterWidth + 4, y: y, width: eventWidth, height: 30))
+            view.wantsLayer = true
+            view.layer?.cornerRadius = 5
+            view.layer?.backgroundColor = event.color.withAlphaComponent(0.85).cgColor
+
+            let typeIcon = event.schedule.type == "swarm" ? "S" : "P"
+            let nameLabel = NSTextField(labelWithString: "[\(typeIcon)] \(event.schedule.name)")
+            nameLabel.font = .systemFont(ofSize: 11, weight: .medium)
+            nameLabel.textColor = .white
+            nameLabel.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(nameLabel)
+
+            let timeStr = String(format: "%02d:%02d", comps.hour!, comps.minute!)
+            let detailLabel = NSTextField(labelWithString: "\(timeStr) - \(event.schedule.target) (\(event.schedule.projectName))")
+            detailLabel.font = .systemFont(ofSize: 9)
+            detailLabel.textColor = NSColor.white.withAlphaComponent(0.8)
+            detailLabel.lineBreakMode = .byTruncatingTail
+            detailLabel.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(detailLabel)
+
+            NSLayoutConstraint.activate([
+                nameLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 3),
+                nameLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 6),
+                nameLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -6),
+                detailLabel.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -3),
+                detailLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 6),
+                detailLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -6),
+            ])
+
+            let click = NSClickGestureRecognizer(target: self, action: #selector(eventClicked(_:)))
+            view.addGestureRecognizer(click)
+            objc_setAssociatedObject(view, &CalendarDayView.eventKey, event.schedule.name, .OBJC_ASSOCIATION_RETAIN)
+
+            contentView.addSubview(view)
+            eventViews.append(view)
+        }
+
+        // High-frequency banners
+        let hfEvents = events.filter { $0.date >= dayStart && $0.date < dayEnd && $0.isHighFrequency }
+        var hfSeen = Set<String>()
+        var hfY = totalHeight - 4.0
+        for event in hfEvents {
+            let key = event.schedule.name
+            guard !hfSeen.contains(key) else { continue }
+            hfSeen.insert(key)
+            hfY -= 18
+            let view = NSView(frame: NSRect(x: gutterWidth + 4, y: hfY, width: eventWidth, height: 16))
+            view.wantsLayer = true
+            view.layer?.cornerRadius = 3
+            view.layer?.backgroundColor = event.color.withAlphaComponent(0.7).cgColor
+            let label = NSTextField(labelWithString: "\(event.schedule.name) (high-frequency)")
+            label.font = .systemFont(ofSize: 9, weight: .medium)
+            label.textColor = .white
+            label.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 4),
+                label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            ])
+            contentView.addSubview(view)
+        }
+
+        // "Now" line
+        if cal.isDate(currentDate, inSameDayAs: Date()) {
+            let nowComps = cal.dateComponents([.hour, .minute], from: Date())
+            let nowMinute = CGFloat(nowComps.hour! * 60 + nowComps.minute!)
+            let nowY = totalHeight - (nowMinute / 60.0) * hourHeight
+            let line = NSView(frame: NSRect(x: gutterWidth, y: nowY, width: width - gutterWidth, height: 2))
+            line.wantsLayer = true
+            line.layer?.backgroundColor = NSColor.systemRed.cgColor
+            line.autoresizingMask = [.width]
+            contentView.addSubview(line)
+        }
+
+        // Click for empty slots
+        let click = NSClickGestureRecognizer(target: self, action: #selector(gridClicked(_:)))
+        contentView.addGestureRecognizer(click)
+
+        // Scroll to 8 AM
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let scrollY = totalHeight - 8 * self.hourHeight - self.scrollView.bounds.height / 2
+            self.scrollView.contentView.scroll(to: NSPoint(x: 0, y: max(0, scrollY)))
+        }
+    }
+
+    private static var eventKey: UInt8 = 0
+
+    @objc private func eventClicked(_ sender: NSClickGestureRecognizer) {
+        guard let view = sender.view,
+              let name = objc_getAssociatedObject(view, &CalendarDayView.eventKey) as? String,
+              let event = events.first(where: { $0.schedule.name == name }) else { return }
+        onEventClicked?(event, view)
+    }
+
+    @objc private func gridClicked(_ sender: NSClickGestureRecognizer) {
+        let location = sender.location(in: contentView)
+        let totalHeight = hourHeight * 24
+
+        guard location.x > gutterWidth else { return }
+
+        let minuteFromTop = (totalHeight - location.y) / hourHeight * 60
+        let hour = Int(minuteFromTop / 60)
+        let minute = (Int(minuteFromTop) % 60 / 30) * 30
+
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month, .day], from: currentDate)
+        comps.hour = max(0, min(23, hour))
+        comps.minute = max(0, min(59, minute))
+
+        if let date = cal.date(from: comps) {
+            onEmptySlotClicked?(date)
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        layoutDay()
     }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -320,6 +320,32 @@ cronCmd
   });
 
 cronCmd
+  .command('add')
+  .description('Add a new scheduled run')
+  .requiredOption('--name <name>', 'Schedule name')
+  .requiredOption('--cron <expression>', 'Cron expression (5-field)')
+  .option('--swarm <name>', 'Swarm template name')
+  .option('--prompt <name>', 'Prompt template name')
+  .option('--var <key=value...>', 'Variables', collectVars, [])
+  .option('--project <path>', 'Project root (defaults to cwd)')
+  .option('--json', 'Output as JSON')
+  .action(async (options) => {
+    const { cronAddCommand } = await import('./commands/cron.js');
+    await cronAddCommand(options);
+  });
+
+cronCmd
+  .command('remove')
+  .description('Remove a scheduled run')
+  .requiredOption('--name <name>', 'Schedule name to remove')
+  .option('--project <path>', 'Project root (defaults to cwd)')
+  .option('--json', 'Output as JSON')
+  .action(async (options) => {
+    const { cronRemoveCommand } = await import('./commands/cron.js');
+    await cronRemoveCommand(options);
+  });
+
+cronCmd
   .command('_daemon', { hidden: true })
   .description('Internal: run the cron daemon (called by ppg cron start)')
   .action(async () => {

--- a/src/commands/cron.ts
+++ b/src/commands/cron.ts
@@ -1,13 +1,15 @@
 import fs from 'node:fs/promises';
+import YAML from 'yaml';
 import { getRepoRoot } from '../core/worktree.js';
 import { readManifest } from '../core/manifest.js';
-import { loadSchedules, getNextRun, formatCronHuman } from '../core/schedule.js';
+import { loadSchedules, getNextRun, formatCronHuman, validateCronExpression } from '../core/schedule.js';
 import { runCronDaemon, isCronRunning, getCronPid, readCronLog } from '../core/cron.js';
 import * as tmux from '../core/tmux.js';
-import { cronPidPath, manifestPath } from '../lib/paths.js';
+import { cronPidPath, manifestPath, schedulesPath, ppgDir } from '../lib/paths.js';
 import { PpgError, NotInitializedError } from '../lib/errors.js';
 import { output, formatTable, info, success, warn } from '../lib/output.js';
 import type { Column } from '../lib/output.js';
+import type { ScheduleEntry, SchedulesConfig } from '../types/schedule.js';
 
 export interface CronOptions {
   json?: boolean;
@@ -182,6 +184,133 @@ export async function cronDaemonCommand(): Promise<void> {
   const projectRoot = await getRepoRoot();
   await requireInit(projectRoot);
   await runCronDaemon(projectRoot);
+}
+
+export interface CronAddOptions {
+  name: string;
+  cron: string;
+  swarm?: string;
+  prompt?: string;
+  var?: string[];
+  project?: string;
+  json?: boolean;
+}
+
+export async function cronAddCommand(options: CronAddOptions): Promise<void> {
+  const projectRoot = options.project ?? await getRepoRoot();
+  const json = options.json ?? false;
+
+  // Validate: exactly one of swarm or prompt
+  if (options.swarm && options.prompt) {
+    throw new PpgError('Specify either --swarm or --prompt, not both', 'INVALID_ARGS');
+  }
+  if (!options.swarm && !options.prompt) {
+    throw new PpgError('Must specify either --swarm or --prompt', 'INVALID_ARGS');
+  }
+
+  // Validate cron expression
+  validateCronExpression(options.cron);
+
+  // Ensure .ppg directory exists
+  await fs.mkdir(ppgDir(projectRoot), { recursive: true });
+
+  // Load existing schedules (or start with empty array if file doesn't exist)
+  const filePath = schedulesPath(projectRoot);
+  let schedules: ScheduleEntry[] = [];
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = YAML.parse(raw) as SchedulesConfig | null;
+    if (parsed && Array.isArray(parsed.schedules)) {
+      schedules = parsed.schedules;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
+  // Validate name is unique
+  if (schedules.some((s) => s.name === options.name)) {
+    throw new PpgError(`Schedule "${options.name}" already exists`, 'INVALID_ARGS');
+  }
+
+  // Build the new entry
+  const entry: ScheduleEntry = {
+    name: options.name,
+    cron: options.cron,
+  };
+  if (options.swarm) {
+    entry.swarm = options.swarm;
+  }
+  if (options.prompt) {
+    entry.prompt = options.prompt;
+  }
+  if (options.var && options.var.length > 0) {
+    const vars: Record<string, string> = {};
+    for (const v of options.var) {
+      const eq = v.indexOf('=');
+      if (eq === -1) {
+        throw new PpgError(`Invalid variable format: "${v}" — expected key=value`, 'INVALID_ARGS');
+      }
+      vars[v.slice(0, eq)] = v.slice(eq + 1);
+    }
+    entry.vars = vars;
+  }
+
+  // Append and write back
+  schedules.push(entry);
+  const config: SchedulesConfig = { schedules };
+  await fs.writeFile(filePath, YAML.stringify(config), 'utf-8');
+
+  if (json) {
+    output({ success: true, schedule: entry }, true);
+  } else {
+    success(`Schedule "${options.name}" added`);
+  }
+}
+
+export interface CronRemoveOptions {
+  name: string;
+  project?: string;
+  json?: boolean;
+}
+
+export async function cronRemoveCommand(options: CronRemoveOptions): Promise<void> {
+  const projectRoot = options.project ?? await getRepoRoot();
+  const json = options.json ?? false;
+
+  // Load existing schedules
+  const filePath = schedulesPath(projectRoot);
+  let schedules: ScheduleEntry[] = [];
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = YAML.parse(raw) as SchedulesConfig | null;
+    if (parsed && Array.isArray(parsed.schedules)) {
+      schedules = parsed.schedules;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new PpgError(`Schedule "${options.name}" not found`, 'INVALID_ARGS');
+    }
+    throw err;
+  }
+
+  // Find and remove
+  const before = schedules.length;
+  const filtered = schedules.filter((s) => s.name !== options.name);
+  if (filtered.length === before) {
+    throw new PpgError(`Schedule "${options.name}" not found`, 'INVALID_ARGS');
+  }
+
+  // Write back (even if empty, keep the file with empty schedules array)
+  const config: SchedulesConfig = { schedules: filtered };
+  await fs.writeFile(filePath, YAML.stringify(config), 'utf-8');
+
+  if (json) {
+    output({ success: true, removed: options.name }, true);
+  } else {
+    success(`Schedule "${options.name}" removed`);
+  }
 }
 
 async function requireInit(projectRoot: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Replaces the table+YAML editor Schedules tab with a full calendar UI (Day, Week, Month views)
- Adds new `CronParser.swift` — a reusable cron expression evaluator for computing occurrences in date ranges
- Events are rendered as colored pills in month view, time-positioned blocks in week/day views
- Event detail popovers show schedule info with Edit/Delete actions
- Clicking empty time slots pre-fills a new schedule dialog with the selected time
- Project-based deterministic color coding for multi-project calendars
- Adds `ppg cron add` and `ppg cron remove` CLI commands with `--json` support

## Test plan
- [ ] Open dashboard, navigate to Schedules tab — calendar month view loads
- [ ] Switch between Day, Week, Month views via segmented control
- [ ] Navigate forward/back with arrows, return to today with "Today" button
- [ ] Click a day cell in month view — switches to day view for that date
- [ ] Click an event pill — popover shows schedule details
- [ ] Click "+ New Schedule" — create dialog appears and schedule is saved
- [ ] Click empty time slot in week/day view — new schedule dialog pre-fills time
- [ ] Edit and delete schedules from event popover
- [ ] Daemon start/stop controls work
- [ ] Run `ppg cron add --name test --cron "0 9 * * *" --prompt my-template --json`
- [ ] Run `ppg cron remove --name test --json`
- [ ] Run `ppg cron list` to verify add/remove worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)