### PR TITLE
feat: add syntax highlighting for markdown and YAML editors

### DIFF
--- a/PPG CLI/PPG CLI/ClaudeMdEditorView.swift
+++ b/PPG CLI/PPG CLI/ClaudeMdEditorView.swift
@@ -199,6 +199,7 @@ class ClaudeMdEditorView: NSView, NSTextStorageDelegate {
         currentFileIndex = index
         isDirty = false
         saveButton.isEnabled = false
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 
     @objc private func fileSwitcherChanged(_ sender: NSPopUpButton) {
@@ -250,5 +251,6 @@ class ClaudeMdEditorView: NSView, NSTextStorageDelegate {
         guard editedMask.contains(.editedCharacters) else { return }
         isDirty = true
         saveButton.isEnabled = true
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 }

--- a/PPG CLI/PPG CLI/PpgAgentsView.swift
+++ b/PPG CLI/PPG CLI/PpgAgentsView.swift
@@ -178,6 +178,7 @@ class PpgAgentsView: NSView, NSTextStorageDelegate {
         currentConfigIndex = index
         isDirty = false
         saveButton.isEnabled = false
+        SyntaxHighlighter.highlightYAML(editorTextView.textStorage)
     }
 
     @objc private func projectSwitcherChanged(_ sender: NSPopUpButton) {
@@ -223,5 +224,6 @@ class PpgAgentsView: NSView, NSTextStorageDelegate {
         guard editedMask.contains(.editedCharacters) else { return }
         isDirty = true
         saveButton.isEnabled = true
+        SyntaxHighlighter.highlightYAML(editorTextView.textStorage)
     }
 }

--- a/PPG CLI/PPG CLI/PromptsView.swift
+++ b/PPG CLI/PPG CLI/PromptsView.swift
@@ -454,27 +454,7 @@ class PromptsView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextSto
     }
 
     private func highlightVariables() {
-        guard let storage = editorTextView.textStorage else { return }
-        let fullRange = NSRange(location: 0, length: storage.length)
-        let monoFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        let boldFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .bold)
-
-        storage.beginEditing()
-        storage.addAttributes([
-            .foregroundColor: Theme.primaryText,
-            .font: monoFont,
-        ], range: fullRange)
-
-        let text = storage.string
-        let regex = try! NSRegularExpression(pattern: "\\{\\{\\w+\\}\\}")
-        let matches = regex.matches(in: text, range: fullRange)
-        for match in matches {
-            storage.addAttributes([
-                .foregroundColor: NSColor.systemOrange,
-                .font: boldFont,
-            ], range: match.range)
-        }
-        storage.endEditing()
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 
     // MARK: - Actions

--- a/PPG CLI/PPG CLI/SkillsView.swift
+++ b/PPG CLI/PPG CLI/SkillsView.swift
@@ -572,6 +572,7 @@ class SkillsView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextStor
         editorTextView.textContainer?.widthTracksTextView = true
         editorTextView.textContainerInset = NSSize(width: 8, height: 8)
         editorTextView.autoresizingMask = [.width, .height]
+        editorTextView.textStorage?.delegate = self
 
         editorScrollView.documentView = editorTextView
         editorScrollView.hasVerticalScroller = true
@@ -759,6 +760,7 @@ class SkillsView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextStor
         pendingBodyText = nil
         backButton.isHidden = true
         refsTableView.reloadData()
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 
     private func clearDetailForm() {
@@ -1327,6 +1329,7 @@ class SkillsView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextStor
         editingRefFile = refName
         backButton.isHidden = false
         editorTextView.string = content
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 
     @objc private func backToSkillClicked() {
@@ -1335,5 +1338,13 @@ class SkillsView: NSView, NSTableViewDataSource, NSTableViewDelegate, NSTextStor
         backButton.isHidden = true
         editorTextView.string = pendingBodyText ?? skills[idx].body
         pendingBodyText = nil
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
+    }
+
+    // MARK: - NSTextStorageDelegate
+
+    func textStorage(_ textStorage: NSTextStorage, didProcessEditing editedMask: NSTextStorageEditActions, range editedRange: NSRange, changeInLength delta: Int) {
+        guard editedMask.contains(.editedCharacters) else { return }
+        SyntaxHighlighter.highlightMarkdown(editorTextView.textStorage)
     }
 }

--- a/PPG CLI/PPG CLI/SyntaxHighlighter.swift
+++ b/PPG CLI/PPG CLI/SyntaxHighlighter.swift
@@ -1,0 +1,190 @@
+import AppKit
+
+enum SyntaxHighlighter {
+
+    // MARK: - Fonts
+
+    private static let monoFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    private static let boldFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .bold)
+    private static let italicFont: NSFont = {
+        NSFontManager.shared.convert(
+            NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+            toHaveTrait: .italicFontMask
+        )
+    }()
+    private static let boldItalicFont: NSFont = {
+        NSFontManager.shared.convert(
+            NSFont.monospacedSystemFont(ofSize: 13, weight: .bold),
+            toHaveTrait: .italicFontMask
+        )
+    }()
+
+    // MARK: - Markdown Patterns
+
+    private static let headingRegex = try! NSRegularExpression(pattern: "^#{1,6}\\s+.*$", options: .anchorsMatchLines)
+    private static let boldRegex = try! NSRegularExpression(pattern: "\\*\\*(?!\\s).+?(?<!\\s)\\*\\*|__(?!\\s).+?(?<!\\s)__")
+    private static let italicRegex = try! NSRegularExpression(pattern: "(?<!\\*)\\*(?!\\*)(?!\\s)(.+?)(?<!\\s)(?<!\\*)\\*(?!\\*)|(?<!_)_(?!_)(?!\\s)(.+?)(?<!\\s)(?<!_)_(?!_)")
+    private static let inlineCodeRegex = try! NSRegularExpression(pattern: "`[^`]+`")
+    private static let codeBlockRegex = try! NSRegularExpression(pattern: "^```.*?^```", options: [.anchorsMatchLines, .dotMatchesLineSeparators])
+    private static let linkRegex = try! NSRegularExpression(pattern: "\\[([^\\]]+)\\]\\(([^)]+)\\)")
+    private static let listRegex = try! NSRegularExpression(pattern: "^(\\s*)([-*]|\\d+\\.)\\s", options: .anchorsMatchLines)
+    private static let variableRegex = try! NSRegularExpression(pattern: "\\{\\{\\w+\\}\\}")
+    private static let frontmatterRegex = try! NSRegularExpression(pattern: "\\A---\\n.*?\\n---", options: .dotMatchesLineSeparators)
+    private static let htmlCommentRegex = try! NSRegularExpression(pattern: "<!--.*?-->", options: .dotMatchesLineSeparators)
+
+    // MARK: - YAML Patterns
+
+    private static let yamlCommentRegex = try! NSRegularExpression(pattern: "#.*$", options: .anchorsMatchLines)
+    private static let yamlTopKeyRegex = try! NSRegularExpression(pattern: "^[A-Za-z_][A-Za-z0-9_-]*(?=\\s*:)", options: .anchorsMatchLines)
+    private static let yamlKeyRegex = try! NSRegularExpression(pattern: "^(\\s+)[A-Za-z_][A-Za-z0-9_-]*(?=\\s*:)", options: .anchorsMatchLines)
+    private static let yamlStringRegex = try! NSRegularExpression(pattern: "(?<=[:\\s])(['\"]).*?\\1")
+    private static let yamlBoolRegex = try! NSRegularExpression(pattern: "(?<=:\\s)\\b(true|false)\\b")
+    private static let yamlNumberRegex = try! NSRegularExpression(pattern: "(?<=:\\s)-?\\d+\\.?\\d*\\b")
+    private static let yamlListMarkerRegex = try! NSRegularExpression(pattern: "^(\\s+)-\\s", options: .anchorsMatchLines)
+
+    // MARK: - Public API
+
+    static func highlightMarkdown(_ storage: NSTextStorage?) {
+        guard let storage = storage, storage.length > 0 else { return }
+        let fullRange = NSRange(location: 0, length: storage.length)
+        let text = storage.string
+
+        storage.beginEditing()
+
+        // Reset to base style
+        storage.addAttributes([
+            .foregroundColor: Theme.primaryText,
+            .font: monoFont,
+        ], range: fullRange)
+
+        // Code blocks (before other rules so they take precedence)
+        for match in codeBlockRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemGray, range: match.range)
+        }
+
+        // Frontmatter delimiters
+        for match in frontmatterRegex.matches(in: text, range: fullRange) {
+            storage.addAttributes([
+                .foregroundColor: NSColor.systemGray,
+                .font: italicFont,
+            ], range: match.range)
+        }
+
+        // HTML comments
+        for match in htmlCommentRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemGray, range: match.range)
+        }
+
+        // Headings
+        for match in headingRegex.matches(in: text, range: fullRange) {
+            storage.addAttributes([
+                .foregroundColor: NSColor.systemBlue,
+                .font: boldFont,
+            ], range: match.range)
+        }
+
+        // Bold
+        for match in boldRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.font, value: boldFont, range: match.range)
+        }
+
+        // Italic
+        for match in italicRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.font, value: italicFont, range: match.range)
+        }
+
+        // Inline code (after bold/italic so it overrides within backticks)
+        for match in inlineCodeRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemGray, range: match.range)
+        }
+
+        // Links — color the URL part
+        for match in linkRegex.matches(in: text, range: fullRange) {
+            let urlRange = match.range(at: 2)
+            if urlRange.location != NSNotFound {
+                storage.addAttribute(.foregroundColor, value: NSColor.systemBlue, range: urlRange)
+            }
+        }
+
+        // List markers
+        for match in listRegex.matches(in: text, range: fullRange) {
+            let markerRange = match.range(at: 2)
+            if markerRange.location != NSNotFound {
+                storage.addAttribute(.foregroundColor, value: NSColor.systemGray, range: markerRange)
+            }
+        }
+
+        // {{VAR}} template variables
+        for match in variableRegex.matches(in: text, range: fullRange) {
+            storage.addAttributes([
+                .foregroundColor: NSColor.systemOrange,
+                .font: boldFont,
+            ], range: match.range)
+        }
+
+        storage.endEditing()
+    }
+
+    static func highlightYAML(_ storage: NSTextStorage?) {
+        guard let storage = storage, storage.length > 0 else { return }
+        let fullRange = NSRange(location: 0, length: storage.length)
+        let text = storage.string
+
+        storage.beginEditing()
+
+        // Reset to base style
+        storage.addAttributes([
+            .foregroundColor: Theme.primaryText,
+            .font: monoFont,
+        ], range: fullRange)
+
+        // Comments (apply first, then keys/values override non-comment regions)
+        for match in yamlCommentRegex.matches(in: text, range: fullRange) {
+            storage.addAttributes([
+                .foregroundColor: NSColor.systemGray,
+                .font: italicFont,
+            ], range: match.range)
+        }
+
+        // Top-level keys (bold cyan)
+        for match in yamlTopKeyRegex.matches(in: text, range: fullRange) {
+            storage.addAttributes([
+                .foregroundColor: NSColor.systemCyan,
+                .font: boldFont,
+            ], range: match.range)
+        }
+
+        // Indented keys (cyan, regular weight)
+        for match in yamlKeyRegex.matches(in: text, range: fullRange) {
+            // Only color the key itself, not the leading whitespace
+            let matchStr = (text as NSString).substring(with: match.range)
+            let trimmed = matchStr.trimmingCharacters(in: .whitespaces)
+            let keyStart = match.range.location + match.range.length - trimmed.count
+            let keyRange = NSRange(location: keyStart, length: trimmed.count)
+            storage.addAttribute(.foregroundColor, value: NSColor.systemCyan, range: keyRange)
+        }
+
+        // String values
+        for match in yamlStringRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemGreen, range: match.range)
+        }
+
+        // Booleans
+        for match in yamlBoolRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemOrange, range: match.range)
+        }
+
+        // Numbers
+        for match in yamlNumberRegex.matches(in: text, range: fullRange) {
+            storage.addAttribute(.foregroundColor, value: NSColor.systemPurple, range: match.range)
+        }
+
+        // List markers
+        for match in yamlListMarkerRegex.matches(in: text, range: fullRange) {
+            let dashRange = NSRange(location: match.range.location + match.range.length - 2, length: 1)
+            storage.addAttribute(.foregroundColor, value: NSColor.systemGray, range: dashRange)
+        }
+
+        storage.endEditing()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SyntaxHighlighter.swift` with `highlightMarkdown` and `highlightYAML` static functions using NSColor system colors (auto dark/light mode)
- Markdown highlighting: headings (bold blue), bold, italic, inline code, code blocks, links, list markers, `{{VAR}}` templates (orange bold), YAML frontmatter, HTML comments
- YAML highlighting: keys (cyan, bold for top-level), quoted strings (green), booleans (orange), numbers (purple), comments (gray italic), list markers
- Integrate into PromptsView (replaces old highlightVariables), ClaudeMdEditorView, PpgAgentsView (YAML), and SkillsView
- Live highlighting updates as user types via NSTextStorageDelegate

## Test plan
- [ ] Open Prompts tab — verify markdown highlighting on headings, bold, code, `{{VAR}}` markers
- [ ] Open CLAUDE.md editor — verify markdown highlighting on load and while typing
- [ ] Open Agents tab — verify YAML highlighting on keys, strings, booleans, numbers, comments
- [ ] Open Skills tab — verify markdown highlighting on skill body and reference files
- [ ] Toggle between dark and light mode — verify colors adapt automatically
- [ ] Type new content in each editor — verify highlighting updates live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time syntax highlighting for Markdown content across editor views
  * Added YAML syntax highlighting for configuration file editing
  * Syntax highlighting now displays immediately when files are loaded and updates dynamically as you type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->