### PR TITLE
feat: implement iOS state management (AppState + ManifestStore)

### DIFF
--- a/ios/PPGMobile/PPGMobile/State/AppState.swift
+++ b/ios/PPGMobile/PPGMobile/State/AppState.swift
@@ -139,7 +139,11 @@ final class AppState {
         // Clean up orphaned Keychain token if replacing a duplicate
         if let existing = connections.first(where: { $0.host == connection.host && $0.port == connection.port }),
            existing.id != connection.id {
-            try? TokenStorage.delete(for: existing.id)
+            do {
+                try TokenStorage.delete(for: existing.id)
+            } catch {
+                errorMessage = "Failed to remove stale credentials from Keychain."
+            }
         }
 
         if let index = connections.firstIndex(where: { $0.host == connection.host && $0.port == connection.port }) {
@@ -160,7 +164,11 @@ final class AppState {
             disconnect()
         }
         connections.removeAll { $0.id == connection.id }
-        try? TokenStorage.delete(for: connection.id)
+        do {
+            try TokenStorage.delete(for: connection.id)
+        } catch {
+            errorMessage = "Failed to remove connection credentials from Keychain."
+        }
         saveConnections()
 
         if let lastId = UserDefaults.standard.string(forKey: DefaultsKey.lastConnectionId),
@@ -236,25 +244,58 @@ final class AppState {
     // MARK: - Persistence
 
     private func loadConnections() {
-        guard let data = UserDefaults.standard.data(forKey: DefaultsKey.savedConnections),
-              let persisted = try? JSONDecoder().decode([PersistedConnection].self, from: data) else {
+        guard let data = UserDefaults.standard.data(forKey: DefaultsKey.savedConnections) else {
             return
         }
-        connections = persisted.compactMap { entry in
-            guard let token = try? TokenStorage.load(for: entry.id) else { return nil }
-            return entry.toServerConnection(token: token)
+
+        let persisted: [PersistedConnection]
+        do {
+            persisted = try JSONDecoder().decode([PersistedConnection].self, from: data)
+        } catch {
+            errorMessage = "Failed to load saved connections."
+            return
+        }
+
+        var loaded: [ServerConnection] = []
+        var failedTokenLoad = false
+        for entry in persisted {
+            do {
+                let token = try TokenStorage.load(for: entry.id)
+                loaded.append(entry.toServerConnection(token: token))
+            } catch {
+                failedTokenLoad = true
+            }
+        }
+        connections = loaded
+
+        if failedTokenLoad {
+            errorMessage = "Some saved connection tokens could not be loaded."
         }
     }
 
     private func saveConnections() {
         // Persist metadata to UserDefaults (no tokens)
         let persisted = connections.map { PersistedConnection(from: $0) }
-        guard let data = try? JSONEncoder().encode(persisted) else { return }
-        UserDefaults.standard.set(data, forKey: DefaultsKey.savedConnections)
+        do {
+            let data = try JSONEncoder().encode(persisted)
+            UserDefaults.standard.set(data, forKey: DefaultsKey.savedConnections)
+        } catch {
+            errorMessage = "Failed to save connections."
+            return
+        }
 
         // Persist tokens to Keychain
+        var failedTokenSave = false
         for connection in connections {
-            try? TokenStorage.save(token: connection.token, for: connection.id)
+            do {
+                try TokenStorage.save(token: connection.token, for: connection.id)
+            } catch {
+                failedTokenSave = true
+            }
+        }
+
+        if failedTokenSave {
+            errorMessage = "Some connection tokens could not be saved."
         }
     }
 }

--- a/ios/PPGMobile/PPGMobile/State/ManifestStore.swift
+++ b/ios/PPGMobile/PPGMobile/State/ManifestStore.swift
@@ -41,6 +41,7 @@ final class ManifestStore {
     func refresh() async {
         isLoading = true
         error = nil
+        defer { isLoading = false }
 
         do {
             let fetched = try await client.fetchStatus()
@@ -49,8 +50,6 @@ final class ManifestStore {
         } catch {
             self.error = error.localizedDescription
         }
-
-        isLoading = false
     }
 
     // MARK: - Incremental Updates
@@ -71,6 +70,8 @@ final class ManifestStore {
                 worktree.agents[agentId] = agent
                 m.worktrees[wtId] = worktree
                 manifest = m
+                lastRefreshed = Date()
+                error = nil
                 return
             }
         }
@@ -83,6 +84,8 @@ final class ManifestStore {
         worktree.status = status
         m.worktrees[worktreeId] = worktree
         manifest = m
+        lastRefreshed = Date()
+        error = nil
     }
 
     // MARK: - Clear

--- a/src/commands/spawn.test.ts
+++ b/src/commands/spawn.test.ts
@@ -7,6 +7,7 @@ import { spawnAgent } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
 import { agentId, sessionId } from '../lib/id.js';
 import * as tmux from '../core/tmux.js';
+import type { Manifest } from '../types/manifest.js';
 
 vi.mock('node:fs/promises', async () => {
   const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
@@ -79,7 +80,7 @@ const mockedEnsureSession = vi.mocked(tmux.ensureSession);
 const mockedCreateWindow = vi.mocked(tmux.createWindow);
 const mockedSplitPane = vi.mocked(tmux.splitPane);
 
-function createManifest(tmuxWindow = '') {
+function createManifest(tmuxWindow = ''): Manifest {
   return {
     version: 1 as const,
     projectRoot: '/tmp/repo',
@@ -93,7 +94,7 @@ function createManifest(tmuxWindow = '') {
         baseBranch: 'main',
         status: 'active' as const,
         tmuxWindow,
-        agents: {} as Record<string, any>,
+        agents: {},
         createdAt: '2026-02-27T00:00:00.000Z',
       },
     },


### PR DESCRIPTION
## Summary
- **`AppState.swift`** — `@Observable` root state managing server connections, REST/WS lifecycle, UserDefaults persistence, and auto-connect on launch
- **`ManifestStore.swift`** — Separate manifest cache with full REST refresh and incremental WebSocket updates (agent/worktree status changes)
- Connection CRUD with duplicate detection, switching (disconnect → connect), and last-used persistence

## Dependencies
- Requires #77 (data models), #78 (PPGClient), #79 (WebSocketManager) — written against their expected interfaces

## Test plan
- [ ] Verify `AppState` loads/saves connections from UserDefaults correctly
- [ ] Verify auto-connect picks up last-used connection on launch
- [ ] Verify `connect()` tests reachability before activating connection
- [ ] Verify `disconnect()` tears down WebSocket and clears manifest
- [ ] Verify `ManifestStore.refresh()` fetches and caches manifest via REST
- [ ] Verify incremental agent/worktree status updates mutate cached manifest correctly
- [ ] Verify connection switching disconnects current before connecting to new
- [ ] Verify error state surfaces user-facing messages on connection failure

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconnection to the last-used server on app launch
  * Enhanced server connection management with persistent storage across app sessions
  * Real-time manifest caching with incremental updates and synchronization
  * Improved error handling and state tracking for server operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->