### PR TITLE
feat: implement Settings views

### DIFF
--- a/ios/PPGMobile/PPGMobile/Views/Settings/AddServerView.swift
+++ b/ios/PPGMobile/PPGMobile/Views/Settings/AddServerView.swift
@@ -73,16 +73,40 @@ struct AddServerView: View {
     }
 
     private var isValid: Bool {
-        !host.trimmingCharacters(in: .whitespaces).isEmpty
-            && !token.trimmingCharacters(in: .whitespaces).isEmpty
+        !trimmedHost.isEmpty
+            && !trimmedToken.isEmpty
+            && parsedPort != nil
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedHost: String {
+        host.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedToken: String {
+        token.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var parsedPort: Int? {
+        guard
+            let value = Int(port.trimmingCharacters(in: .whitespacesAndNewlines)),
+            (1...65_535).contains(value)
+        else {
+            return nil
+        }
+        return value
     }
 
     private func addServer() {
+        guard let validatedPort = parsedPort else { return }
         let connection = ServerConnection(
-            name: name.trimmingCharacters(in: .whitespaces),
-            host: host.trimmingCharacters(in: .whitespaces),
-            port: Int(port) ?? 7700,
-            token: token.trimmingCharacters(in: .whitespaces)
+            name: trimmedName.isEmpty ? "My Mac" : trimmedName,
+            host: trimmedHost,
+            port: validatedPort,
+            token: trimmedToken
         )
         appState.addConnection(connection)
         Task { await appState.connect(to: connection) }

--- a/ios/PPGMobile/PPGMobile/Views/Settings/SettingsView.swift
+++ b/ios/PPGMobile/PPGMobile/Views/Settings/SettingsView.swift
@@ -9,6 +9,8 @@ struct SettingsView: View {
     @State private var testResult: TestResult?
     @State private var showQRError = false
 
+    private let repositoryURL = URL(string: "https://github.com/2witstudios/ppg-cli")
+
     private enum TestResult: Equatable {
         case testing
         case success
@@ -76,9 +78,7 @@ struct SettingsView: View {
                 testConnectionRow
 
                 Button("Disconnect", role: .destructive) {
-                    Task { @MainActor in
-                        appState.disconnect()
-                    }
+                    appState.disconnect()
                 }
             } else {
                 Text("Not connected")
@@ -146,8 +146,10 @@ struct SettingsView: View {
             LabeledContent("PPG Mobile", value: appVersion)
             LabeledContent("Server Protocol", value: "v1")
 
-            Link(destination: URL(string: "https://github.com/2witstudios/ppg-cli")!) {
-                Label("GitHub Repository", systemImage: "link")
+            if let repositoryURL {
+                Link(destination: repositoryURL) {
+                    Label("GitHub Repository", systemImage: "link")
+                }
             }
         }
     }

--- a/src/commands/spawn.test.ts
+++ b/src/commands/spawn.test.ts
@@ -6,6 +6,7 @@ import { readManifest, resolveWorktree, updateManifest } from '../core/manifest.
 import { spawnAgent } from '../core/agent.js';
 import { getRepoRoot } from '../core/worktree.js';
 import { agentId, sessionId } from '../lib/id.js';
+import type { Manifest } from '../types/manifest.js';
 import * as tmux from '../core/tmux.js';
 
 vi.mock('node:fs/promises', async () => {
@@ -79,7 +80,7 @@ const mockedEnsureSession = vi.mocked(tmux.ensureSession);
 const mockedCreateWindow = vi.mocked(tmux.createWindow);
 const mockedSplitPane = vi.mocked(tmux.splitPane);
 
-function createManifest(tmuxWindow = '') {
+function createManifest(tmuxWindow = ''): Manifest {
   return {
     version: 1 as const,
     projectRoot: '/tmp/repo',
@@ -103,7 +104,7 @@ function createManifest(tmuxWindow = '') {
 }
 
 describe('spawnCommand', () => {
-  let manifestState = createManifest();
+  let manifestState: Manifest = createManifest();
   let nextAgent = 1;
   let nextSession = 1;
 


### PR DESCRIPTION
## Summary
- **`SettingsView.swift`** — full server management: server list with connect/tap, swipe-to-delete with confirmation dialog, test connection button with async success/failure feedback, QR scanner sheet integration, connection status badge, about section with dynamic app version and GitHub link
- **`AddServerView.swift`** — dedicated form view for manual server entry (name, host, port, token) with input validation, replacing the limited alert-based approach

## Acceptance Criteria
- [x] Server list with add/delete
- [x] QR scanner button (launches QRScannerView, parses result, adds connection)
- [x] Test connection button with success/failure feedback
- [x] Server deletion with confirmation dialog
- [x] About section (app version, links)
- [x] Manual entry form (name, host, port, token)

## Dependencies
- `ServerConnection` model from #77
- `AppState` from #82
- `QRScannerView` from #81

Closes #86